### PR TITLE
Made it possible for submodels to set start values of forces/values.

### DIFF
--- a/Hopsan/TLMPluginLib/TLMPluginInterfaceHydraulic1D.hpp
+++ b/Hopsan/TLMPluginLib/TLMPluginInterfaceHydraulic1D.hpp
@@ -78,6 +78,8 @@ namespace hopsan {
 
             // Register TLM Interface
             mInterfaceId = mpPlugin->RegisteTLMInterface(this->getName().c_str(),1,"Bidirectional","Hydraulic");
+
+            mpPlugin->SetInitialForce1D(mInterfaceId,*mpP1_p);
         }
 
 

--- a/Hopsan/TLMPluginLib/TLMPluginInterfaceSignalOutput.hpp
+++ b/Hopsan/TLMPluginLib/TLMPluginInterfaceSignalOutput.hpp
@@ -72,6 +72,8 @@ namespace hopsan {
 
             // Register TLM Interface
             mInterfaceId = mpPlugin->RegisteTLMInterface(this->getName().c_str(), 1, "Output", "Signal");
+
+            mpPlugin->SetInitialValue(mInterfaceId,*mpP1_x);
         }
 
 

--- a/common/Interfaces/TLMInterface1D.cc
+++ b/common/Interfaces/TLMInterface1D.cc
@@ -159,6 +159,9 @@ void TLMInterface1D::SetTimeData(double time,
         DampedTimeData.push_back(request);
     }
 
+    //Default value is the initial value
+    item.GenForce=InitialForce;
+
     if(Domain == "Hydraulic") {
         TLMPlugin::GetForce1D(-speed, request, Params, &item.GenForce);
     }
@@ -202,6 +205,11 @@ void TLMInterface1D::SendAllData() {
 
     // In data request mode we shutdown after sending the first data package.
     if(Params.mode > 0.0) waitForShutdownFlg = true;
+}
+
+void TLMInterface1D::SetInitialForce(double force)
+{
+    InitialForce = force;
 }
 
 

--- a/common/Interfaces/TLMInterface1D.h
+++ b/common/Interfaces/TLMInterface1D.h
@@ -38,6 +38,9 @@ public:
     //!  DataToSend stores the motion data from the interface. The data is sent
     //! in packet for a time period of [half] TLM delay [depends on solver type]
     std::vector<TLMTimeData1D> DataToSend;
+
+    double InitialForce = 0;
+
     void UnpackTimeData(TLMMessage &mess);
 
     void GetTimeData(TLMTimeData1D &Instance);
@@ -45,6 +48,7 @@ public:
     void GetForce(double time, double speed, double *force);
     void SetTimeData(double time, double position, double speed);
     void SendAllData();
+    void SetInitialForce(double force);
 
     //! linear_interpolate is called with a vector containing 2 points
     //! computes the interpolation (or extrapolation) point with the the linear

--- a/common/Interfaces/TLMInterface3D.cc
+++ b/common/Interfaces/TLMInterface3D.cc
@@ -209,6 +209,13 @@ void TLMInterface3D::SetTimeData(double time,
         DampedTimeData.push_back(request);
     }
 
+    item.GenForce[0] = InitialForce[0];
+    item.GenForce[1] = InitialForce[1];
+    item.GenForce[2] = InitialForce[2];
+    item.GenForce[3] = InitialForce[3];
+    item.GenForce[4] = InitialForce[4];
+    item.GenForce[5] = InitialForce[5];
+
     TLMPlugin::GetForce3D(position, orientation,
                           speed, ang_speed,
                           request, Params,
@@ -306,6 +313,16 @@ void TLMInterface3D::SendAllData() {
 
     // In data request mode we shutdown after sending the first data package.
     if(Params.mode > 0.0) waitForShutdownFlg = true;
+}
+
+void TLMInterface3D::SetInitialForce(double f1, double f2, double f3, double t1, double t2, double t3)
+{
+    InitialForce[0] = f1;
+    InitialForce[1] = f2;
+    InitialForce[2] = f3;
+    InitialForce[3] = t1;
+    InitialForce[4] = t2;
+    InitialForce[5] = t3;
 }
 
 

--- a/common/Interfaces/TLMInterface3D.h
+++ b/common/Interfaces/TLMInterface3D.h
@@ -39,6 +39,8 @@ public:
     //! in packet for a time period of [half] TLM delay [depends on solver type]
     std::vector<TLMTimeData3D> DataToSend;
 
+    double InitialForce[6] = {0,0,0,0,0,0};
+
     //! Evaluate the data from deque for the time specified by this Instance
     //! If OnleForce is set, then the position and velocity are not computed.
     void GetTimeData(TLMTimeData3D& Instance, std::deque<TLMTimeData3D>&  Data, bool OnlyForce);
@@ -49,6 +51,7 @@ public:
     void SetTimeData(double time, double position[], double orientation[], double speed[], double ang_speed[]);
     void TransformTimeDataToCG(std::vector<TLMTimeData3D> &timeData, TLMConnectionParams &params);
     void SendAllData();
+    void SetInitialForce(double f1, double f2, double f3, double t1, double t2, double t3);
 
     //! linear_interpolate is called with a vector containing 2 points
     //! computes the interpolation (or extrapolation) point with the the linear

--- a/common/Interfaces/TLMInterfaceSignal.cc
+++ b/common/Interfaces/TLMInterfaceSignal.cc
@@ -38,6 +38,11 @@ void TLMInterfaceSignal::SendAllData() {
     if( Params.mode > 0.0 ) waitForShutdownFlg = true;
 }
 
+void TLMInterfaceSignal::SetInitialValue(double value)
+{
+    InitialValue = value;
+}
+
 void TLMInterfaceSignal::clean_time_queue(std::deque<TLMTimeDataSignal>& Data, double CleanTime) {
     while( (Data.size() > 3) && (CleanTime > Data[2].time)) {
         Data.pop_front();
@@ -164,6 +169,9 @@ void TLMInterfaceSignal::GetValue( double time,
     TLMTimeDataSignal request;
     request.time = time - Params.Delay;
     GetTimeData(request);
+
+    //Default value is the initial value
+    (*value)=InitialValue;
 
     TLMPlugin::GetValueSignal(request, Params, value);
 }

--- a/common/Interfaces/TLMInterfaceSignal.h
+++ b/common/Interfaces/TLMInterfaceSignal.h
@@ -32,12 +32,15 @@ public:
   //! in packet for a time period of [half] TLM delay [depends on solver type]
   std::vector<TLMTimeDataSignal> DataToSend;
 
+  double InitialValue = 0;
+
   void GetTimeData(TLMTimeDataSignal &Instance);
   void GetTimeData(TLMTimeDataSignal &Instance, std::deque<TLMTimeDataSignal> &Data);
   void SetTimeData(double time, double value);
   void GetValue(double time, double *value);
   void UnpackTimeData(TLMMessage &mess);
   void SendAllData();
+  void SetInitialValue(double value);
 
   // Remove the data that is not needed (Simulation time moved forward)
   // We leave two time points intact, so that interpolation work

--- a/common/Plugin/PluginImplementer.cc
+++ b/common/Plugin/PluginImplementer.cc
@@ -21,6 +21,41 @@ TLMPlugin* TLMPlugin::CreateInstance() {
     return PluginImplementerInstance;
 }
 
+void PluginImplementer::SetInitialForce3D(int interfaceID, double f1, double f2, double f3, double t1, double t2, double t3)
+{
+    // Use the ID to get to the right interface object
+    int idx = GetInterfaceIndex(interfaceID);
+    TLMInterface3D* ifc = dynamic_cast<TLMInterface3D*>(Interfaces[idx]);
+
+    assert(!ifc || (ifc -> GetInterfaceID() == interfaceID));
+
+    ifc->SetInitialForce(f1,f2,f3,t1,t2,t3);
+}
+
+void PluginImplementer::SetInitialValue(int interfaceID, double value)
+{
+    // Use the ID to get to the right interface object
+    int idx = GetInterfaceIndex(interfaceID);
+    TLMInterfaceSignal* ifc = dynamic_cast<TLMInterfaceSignal*>(Interfaces[idx]);
+
+    assert(!ifc || (ifc -> GetInterfaceID() == interfaceID));
+
+    ifc->SetInitialValue(value);
+}
+
+void PluginImplementer::SetInitialForce1D(int interfaceID, double force)
+{
+    //if(!ModelChecked) CheckModel();
+
+    // Use the ID to get to the right interface object
+    int idx = GetInterfaceIndex(interfaceID);
+    TLMInterface1D* ifc = dynamic_cast<TLMInterface1D*>(Interfaces[idx]);
+
+    assert(!ifc || (ifc -> GetInterfaceID() == interfaceID));
+
+    ifc->SetInitialForce(force);
+}
+
 
 void signalHandler_(int signum) {
     // Install default signal handler

--- a/common/Plugin/PluginImplementer.h
+++ b/common/Plugin/PluginImplementer.h
@@ -30,6 +30,11 @@ public:
     //! Catch signals
     void HandleSignal(int signum);
 
+    void SetInitialForce3D(int interfaceID,
+                           double f1, double f2, double f3,
+                           double t1, double t2, double t3);
+    void SetInitialForce1D(int interfaceID, double force);
+    void SetInitialValue(int interfaceID, double value);
 protected:
 
     //! SetDebugOut function enables/disables debug information

--- a/common/Plugin/TLMPlugin.cc
+++ b/common/Plugin/TLMPlugin.cc
@@ -53,9 +53,8 @@ void  TLMPlugin::GetForce3D(double position[],
                             double* force) {
 
     if(Data.time == TIME_WITHOUT_DATA) {
-        for(int i = 0; i < 6; i++) {
-            force[i] = 0.0;
-        }
+        //Do nothing, default value should be initial value
+        return;
     }
     else {
         double f[3] = {Data.GenForce[0], Data.GenForce[1], Data.GenForce[2]};
@@ -78,7 +77,8 @@ void TLMPlugin::GetValueSignal(TLMTimeDataSignal &Data,
                                TLMConnectionParams &Params,
                                double *value) {
     if(Data.time == TIME_WITHOUT_DATA) {
-        (*value) = 0.0;
+        //Do nothing, default value should be initial value
+        return;
     }
     else {
         //No physical connection, so just return the value
@@ -93,7 +93,8 @@ void TLMPlugin::GetForce1D(double speed,
                            double *force) {
 
     if(Data.time == TIME_WITHOUT_DATA) {
-        (*force) = 0.0;
+        //Do nothing, default force should be initial value
+        return;
     }
     else {
         double f = Data.GenForce;

--- a/common/Plugin/TLMPlugin.h
+++ b/common/Plugin/TLMPlugin.h
@@ -130,6 +130,12 @@ public:
                                    std::string &Name,
                                    std::string &Value) = 0;
 
+    virtual void SetInitialValue(int interfaceID, double value) = 0;
+    virtual void SetInitialForce1D(int interfaceID, double force) = 0;
+    virtual void SetInitialForce3D(int interfaceID,
+                                   double f1, double f2, double f3,
+                                   double t1, double t2, double t3) = 0;
+
     //! Check if the object is initialized (Init was called).
     bool IsInitialized() const { return Initialized; }
 


### PR DESCRIPTION
Salves can set a start value by calling SetInitialValue(), SetInitialForce1D() or SetInitialForce3D(). It is possible to have different start values on different sides of a connection, since the variables are decoupled.

Tested for signal and 1D connections in Hopsan wrapper. Backwards compatibility is also verified (hence, all models which does not set initial values will still simulate as they used to).