### PR TITLE
Allow closing sockets without permission.

### DIFF
--- a/common/Communication/ManagerCommHandler.cc
+++ b/common/Communication/ManagerCommHandler.cc
@@ -534,6 +534,10 @@ void ManagerCommHandler::ReaderThreadRun() {
                         nClosedSock++;
                     }
                 }
+                else {
+                    //Socket was closed without permission
+                    nClosedSock++;
+                }
             }
         }
     }


### PR DESCRIPTION
Some slaves do not send close requests, so we should not wait forever for them. If a socket is closed, it is closed.