### PR TITLE
Proper shutdown after fetch interfaces

### DIFF
--- a/common/Communication/ManagerCommHandler.cc
+++ b/common/Communication/ManagerCommHandler.cc
@@ -531,7 +531,6 @@ void ManagerCommHandler::ReaderThreadRun() {
                     else {
                         // CommMode == InterfaceRequestMode
                         UnpackAndStoreTimeData(*message);
-                        nClosedSock++;
                     }
                 }
                 else {


### PR DESCRIPTION
Counter for closed sockets was inremented too often, so all interfaces did not receive proper start values.