### PR TITLE
Add C++11 flag for manager and monitor

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -13,6 +13,8 @@ endif
 include $(MAKEFILEHEADHOME)/Makefile.head
 MISCHOME = ../extralibs/misc
 
+CC += -std=c++11 
+
 SRCCLT= Plugin/PluginImplementer.cc \
 	Plugin/MonitoringPluginImplementer.cc \
 	Communication/TLMClientComm.cc \


### PR DESCRIPTION
This suppresses a lot of unnecessary compiler warnings.