### PR TITLE
Enable warning output. Print errors and warnings to cout.

### DIFF
--- a/common/Logging/TLMErrorLog.cc
+++ b/common/Logging/TLMErrorLog.cc
@@ -65,6 +65,7 @@ void TLMErrorLog::SetDebugOut(bool Enable) {
 // then terminates the program abnormally.
 void TLMErrorLog::FatalError(const std::string& mess) {
     Open();
+    std::cout << TimeStr() << " Fatal error: " << mess << std::endl;
     *outStream << TimeStr() << " Fatal error: " << mess << std::endl;
     if(NormalErrorLogOn) {
         _strtime(tmpbuf);
@@ -91,6 +92,7 @@ void  TLMErrorLog::Warning(const std::string& mess) {
 
     if(WarningOn) {
         Open();
+        std::cout << TimeStr() << " Warning: " << mess << std::endl;
         *outStream << TimeStr() << " Warning: " << mess << std::endl;
 
         if(NormalErrorLogOn) {

--- a/common/ManagerMain.cc
+++ b/common/ManagerMain.cc
@@ -156,6 +156,7 @@ int main(int argc, char* argv[]) {
     // Debug on?
     if(debugFlg || comMode == ManagerCommHandler::InterfaceRequestMode) {       //Always enable debug for interface request /robbr
         TLMErrorLog::SetDebugOut(true);
+        TLMErrorLog::SetWarningOut(true);
     }
     
     // Create the meta model object


### PR DESCRIPTION
Messages printed through cout will show up in OMEdit dialog. This makes it easier for the user to understand why the simulation did not work.