### PR TITLE
Check the model for errors prior to simulation.

### DIFF
--- a/common/CompositeModels/CompositeModel.h
+++ b/common/CompositeModels/CompositeModel.h
@@ -509,6 +509,8 @@ public:
     //! Destructor
     ~CompositeModel();
 
+    bool CheckTheModel();
+
     //! Add ComponentProxy to the model and return its ID.
     int RegisterTLMComponentProxy(const std::string& Name,
                                   const std::string& StartCommand,

--- a/common/ManagerMain.cc
+++ b/common/ManagerMain.cc
@@ -171,6 +171,8 @@ int main(int argc, char* argv[]) {
         // Note: Skip loading connections in interface request mode in case an interface no longer exists
         modelReader.ReadModel(inFile,comMode == ManagerCommHandler::InterfaceRequestMode, singleModel);
     }
+
+    theModel.CheckTheModel();
     
     // Set preferred network port
     if(serverPort > 0) {


### PR DESCRIPTION
Causalities and domains should match.
Interfaces shall not be connected more than once.
Warn user about unconnected interfaces.