### PR TITLE
Fetch interface feature should work for multiple connections and sinks

### DIFF
--- a/common/Interfaces/TLMInterfaceSignal.cc
+++ b/common/Interfaces/TLMInterfaceSignal.cc
@@ -74,6 +74,8 @@ void TLMInterfaceSignal::GetTimeData(TLMTimeDataSignal& Instance, std::deque<TLM
         // We always assume no waves initially.
         Instance.Value = 0.0;
         Instance.time = TLMPlugin::TIME_WITHOUT_DATA;
+
+        if( Params.mode > 0.0 ) waitForShutdownFlg = true;
         return;
     }
 
@@ -128,6 +130,7 @@ void TLMInterfaceSignal::GetTimeData(TLMTimeDataSignal& Instance, std::deque<TLM
             }
         }
     }
+    if( Params.mode > 0.0 ) waitForShutdownFlg = true;
 }
 
 

--- a/common/Plugin/PluginImplementer.h
+++ b/common/Plugin/PluginImplementer.h
@@ -83,6 +83,8 @@ protected:
                        double maxStep,
                        std::string ServerName);
 
+    void InterfaceReadyForTakedown(std::string IfcName);
+
     void AwaitClosePermission();
 
     //! Register TLM interface sends a registration request to TLMManager
@@ -180,6 +182,8 @@ protected:
 
     //! Maximum solver time step
     double MaxStep;
+
+    size_t nIfcWaitingForTakedown = 0;
 
 };
 


### PR DESCRIPTION
Instead of each component closing after first output interface, they should close after all interfaces have sent and/or received data.
  