### PR TITLE
Renamed CompositeModel to avoid name conflict with OMSimulator.

### DIFF
--- a/common/Communication/ManagerCommHandler.h
+++ b/common/Communication/ManagerCommHandler.h
@@ -35,7 +35,7 @@ private:
     TLMManagerComm Comm;
 
     //! Meta-model
-    CompositeModel& TheModel;
+    omtlm_CompositeModel& TheModel;
 
     bool MonitorConnected;
 
@@ -69,7 +69,7 @@ private:
 
 public:
     //! Constructor.
-    ManagerCommHandler(CompositeModel& Model):
+    ManagerCommHandler(omtlm_CompositeModel& Model):
         MessageQueue(),
         Comm(Model.GetComponentsNum(), Model.GetSimParams().GetPort()),
         TheModel(Model),

--- a/common/CompositeModels/CompositeModel.cc
+++ b/common/CompositeModels/CompositeModel.cc
@@ -145,13 +145,13 @@ void child_signal_handler(int s) {
 }
 
 // Constructor
-CompositeModel::CompositeModel() {
+omtlm_CompositeModel::omtlm_CompositeModel() {
     signal(SIGCHLD, child_signal_handler);
 }
 #endif
 
 // Destructor
-CompositeModel::~CompositeModel() {
+omtlm_CompositeModel::~omtlm_CompositeModel() {
     // Clean-up memory allocated by arrays
     {
         for(ComponentsVector::iterator i = Components.begin();
@@ -173,7 +173,7 @@ CompositeModel::~CompositeModel() {
   }
 }
 
-bool CompositeModel::CheckTheModel()
+bool omtlm_CompositeModel::CheckTheModel()
 {
     TLMErrorLog::Info("Checking model...");
 
@@ -243,7 +243,7 @@ bool CompositeModel::CheckTheModel()
 
 
 // Add ComponentProxy to the model and return its ID.
-int CompositeModel::RegisterTLMComponentProxy(const string& Name,
+int omtlm_CompositeModel::RegisterTLMComponentProxy(const string& Name,
                                          const string& StartCommand,
                                          const string& ModelName,
                                          int SolverMode,
@@ -255,7 +255,7 @@ int CompositeModel::RegisterTLMComponentProxy(const string& Name,
 
 // Find a Component by its name and return the ID
 // Return -1 if not component was found.. 
-int CompositeModel::GetTLMComponentID(const string& Name) {
+int omtlm_CompositeModel::GetTLMComponentID(const string& Name) {
     for(int i = Components.size() - 1; i >= 0; --i) {
         if(Components[i]->GetName() == Name) {
             return i;
@@ -264,7 +264,7 @@ int CompositeModel::GetTLMComponentID(const string& Name) {
     return -1;
 }
 
-int CompositeModel::GetTLMInterfaceID(string& FullName) {
+int omtlm_CompositeModel::GetTLMInterfaceID(string& FullName) {
 
     string::size_type DotPos = FullName.find('.');  // Component name is the part before '.'
     string ComponentName = FullName.substr(0, DotPos);
@@ -278,7 +278,7 @@ int CompositeModel::GetTLMInterfaceID(string& FullName) {
 }
 
 // Add TLM interface proxy with a given name to the Model, return its ID.
-int CompositeModel::RegisterTLMInterfaceProxy(const int ComponentID, string& Name, int Dimensions,
+int omtlm_CompositeModel::RegisterTLMInterfaceProxy(const int ComponentID, string& Name, int Dimensions,
                                          std::string Causality, std::string Domain) {
     TLMInterfaceProxy* ifc =
             new TLMInterfaceProxy(ComponentID, Interfaces.size(), Name, Dimensions, Causality, Domain);
@@ -295,7 +295,7 @@ int CompositeModel::RegisterTLMInterfaceProxy(const int ComponentID, string& Nam
     return Interfaces.size()-1;
 }
 
-int CompositeModel::RegisterComponentParameterProxy(const int ComponentID, string& Name, string& DefaultValue) {
+int omtlm_CompositeModel::RegisterComponentParameterProxy(const int ComponentID, string& Name, string& DefaultValue) {
     ComponentParameterProxy* par = new ComponentParameterProxy(ComponentID, ComponentParameters.size(), Name, DefaultValue);
 
     TLMErrorLog::Info("Registering parameter proxy."
@@ -311,7 +311,7 @@ int CompositeModel::RegisterComponentParameterProxy(const int ComponentID, strin
 
 // Find TLMInterface belonging to a given component (ID)
 // with a specified name and return its ID.
-int CompositeModel::GetTLMInterfaceID(const int ComponentID, string& Name) {
+int omtlm_CompositeModel::GetTLMInterfaceID(const int ComponentID, string& Name) {
     for(int i = Interfaces.size() - 1; i >= 0; i--) {
         TLMInterfaceProxy& ifc =  GetTLMInterfaceProxy(i);
         if((ifc.GetComponentID() == ComponentID)
@@ -322,7 +322,7 @@ int CompositeModel::GetTLMInterfaceID(const int ComponentID, string& Name) {
     return -1;
 }
 
-int CompositeModel::GetComponentParameterID(const int ComponentID, std::string &Name) {
+int omtlm_CompositeModel::GetComponentParameterID(const int ComponentID, std::string &Name) {
     for(int i = ComponentParameters.size() - 1; i >= 0; i--) {
         ComponentParameterProxy& ifc =  GetComponentParameterProxy(i);
         if((ifc.GetComponentID() == ComponentID)
@@ -338,14 +338,14 @@ int CompositeModel::GetComponentParameterID(const int ComponentID, std::string &
 // Input:
 // ifc1, ifc2 - ID of the TLM interfaces the connection is attaching to.
 // param - parameters of the Connection
-int CompositeModel::RegisterTLMConnection(int ifc1, int ifc2, TLMConnectionParams& param) {
+int omtlm_CompositeModel::RegisterTLMConnection(int ifc1, int ifc2, TLMConnectionParams& param) {
     TLMConnection* conn = new TLMConnection(Connections.size(), ifc1, ifc2, param);
     Connections.insert(Connections.end(), conn);
     return Connections.size() - 1;
 }
 
 // Start components
-void CompositeModel::StartComponents() {
+void omtlm_CompositeModel::StartComponents() {
     for(unsigned i = 0; i < Components.size(); i++) {
         TLMErrorLog::Info(string("-----  Starting External Tool  ----- "));
         TLMErrorLog::Info("Name: "+Components[i]->GetName());
@@ -391,7 +391,7 @@ void CompositeModel::StartComponents() {
     }
 }
 
-bool CompositeModel::CheckProxyComm() {
+bool omtlm_CompositeModel::CheckProxyComm() {
     for(ComponentsVector::iterator it = Components.begin(); it!=Components.end(); ++it) {
         if(((*it)->GetSocketHandle() < 0) || !(*it)->GetReadyToSim()) {
             TLMErrorLog::Info(string("Component ") + (*it)->GetName() + " is not ready for simulation");
@@ -414,7 +414,7 @@ bool CompositeModel::CheckProxyComm() {
 
 
 //! Print meta-model to ostream.
-void CompositeModel::Print(std::ostream &os) {
+void omtlm_CompositeModel::Print(std::ostream &os) {
     os << "Components:" << std::endl;
     for(ComponentsVector::iterator it = Components.begin(); it!=Components.end(); ++it) {
         os << (*it)->GetName() << std::endl;

--- a/common/CompositeModels/CompositeModel.h
+++ b/common/CompositeModels/CompositeModel.h
@@ -484,7 +484,7 @@ public:
 
 //! The class is responsible for the dynamic storage and access to the
 //! meta-model.
-class CompositeModel {
+class omtlm_CompositeModel {
 
     //! MOdel name
     std::string ModelName;
@@ -507,10 +507,10 @@ class CompositeModel {
 public:
     
     //! Constructor
-    CompositeModel();
+    omtlm_CompositeModel();
 
     //! Destructor
-    ~CompositeModel();
+    ~omtlm_CompositeModel();
 
     bool CheckTheModel();
 

--- a/common/CompositeModels/CompositeModelReader.h
+++ b/common/CompositeModels/CompositeModelReader.h
@@ -22,7 +22,7 @@
 class CompositeModelReader {
 
     //! The model object to be filled in during reading
-    CompositeModel& TheModel;
+    omtlm_CompositeModel& TheModel;
 
     //! ReadComponents method reads in Components (SubModels) definition from
     //! the XML file starting from the given xml node that should be "SubModels".
@@ -85,7 +85,7 @@ class CompositeModelReader {
 public:
 
     //! Constructor
-    CompositeModelReader(CompositeModel& model) : TheModel(model) {}
+    CompositeModelReader(omtlm_CompositeModel& model) : TheModel(model) {}
 
 
     //! ReadModel method processes input XML file and creates CompositeModel definition.

--- a/common/Logging/TLMErrorLog.cc
+++ b/common/Logging/TLMErrorLog.cc
@@ -127,7 +127,6 @@ void  TLMErrorLog::Debug(const std::string& mess) {
 
 // A utility function often used to log numerical information
 std::string  TLMErrorLog::ToStdStr(double val) {
-    TLMErrorLog::Debug("Debug 1.");
     return std::to_string(val);
 }
 

--- a/common/ManagerMain.cc
+++ b/common/ManagerMain.cc
@@ -37,7 +37,7 @@ void usage() {
 }
 
 // Print all interfaces position and orientation
-void PrintInterfaceInformation(CompositeModel& theModel) {
+void PrintInterfaceInformation(omtlm_CompositeModel& theModel) {
     std::ofstream interfacefile ("interfaceData.xml");
     if(interfacefile.is_open()) {
         interfacefile << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
@@ -120,8 +120,6 @@ int main(int argc, char* argv[]) {
     ManagerCommHandler::CommunicationMode comMode=ManagerCommHandler::CoSimulationMode;
     std::string singleModel;
 
-    std::cout << "Debug 1\n";
-
     char c;
     while((c = getopt (argc, argv, "dp:m:rs:")) != -1) {
         switch(c) {
@@ -158,7 +156,7 @@ int main(int argc, char* argv[]) {
     }
     
     // Create the meta model object
-    CompositeModel theModel;
+    omtlm_CompositeModel theModel;
 
     {
         // Create model reader for the model

--- a/common/MonitorMain.cc
+++ b/common/MonitorMain.cc
@@ -47,7 +47,7 @@ struct Color {
     }
 };
 
-TLMPlugin* InitializeTLMConnection(CompositeModel& model, std::string& serverName) {
+TLMPlugin* InitializeTLMConnection(omtlm_CompositeModel& model, std::string& serverName) {
     TLMPlugin* TLMlink = MonitoringPluginImplementer::CreateInstance();
 
     TLMErrorLog::Info("Trying to register TLM monitor on host " + serverName);
@@ -85,7 +85,7 @@ TLMPlugin* InitializeTLMConnection(CompositeModel& model, std::string& serverNam
 
 //! Evaluate the data needed for the current time step.
 void MonitorTimeStep(TLMPlugin* TLMlink,
-                     CompositeModel& model,
+                     omtlm_CompositeModel& model,
                      double SimTime,
                      std::map<int, TLMTimeDataSignal>& dataStorageSignal,
                      std::map<int, TLMTimeData1D>& dataStorage1D,
@@ -153,7 +153,7 @@ void MonitorTimeStep(TLMPlugin* TLMlink,
     }
 }
 
-void WriteVisualXMLFile(CompositeModel& model, std::string &baseFileName, std::string &path) {
+void WriteVisualXMLFile(omtlm_CompositeModel& model, std::string &baseFileName, std::string &path) {
     // Get data from TLM-Manager here!
     bool canWriteVisualXMLFile = false;
     int nTLMComponents = model.GetComponentsNum();
@@ -407,7 +407,7 @@ void WriteVisualXMLFile(CompositeModel& model, std::string &baseFileName, std::s
     }
 }
 
-void PrintHeader(CompositeModel& model, std::ofstream& dataFile) {
+void PrintHeader(omtlm_CompositeModel& model, std::ofstream& dataFile) {
     // Get data from TLM-Manager here!
     int nTLMInterfaces = model.GetInterfacesNum();
 
@@ -482,7 +482,7 @@ void PrintHeader(CompositeModel& model, std::ofstream& dataFile) {
     dataFile << std::endl;
 }
 
-void PrintData(CompositeModel& model,
+void PrintData(omtlm_CompositeModel& model,
                std::ofstream& dataFile,
                std::map<int, TLMTimeDataSignal> &dataStorageSignal,
                std::map<int, TLMTimeData1D>& dataStorage1D,
@@ -640,7 +640,7 @@ void PrintData(CompositeModel& model,
     dataFile << std::endl;
 }
 
-void PrintRunStatus(CompositeModel& model, std::ofstream& runFile, tTM_Info& tInfo, double SimTime)  {
+void PrintRunStatus(omtlm_CompositeModel& model, std::ofstream& runFile, tTM_Info& tInfo, double SimTime)  {
     double startTime = model.GetSimParams().GetStartTime();
     double endTime = model.GetSimParams().GetEndTime();
     double timeStep = model.GetSimParams().GetWriteTimeStep();
@@ -724,7 +724,7 @@ int main(int argc, char* argv[]) {
     std::string baseFileName = inFile.substr(0, inFile.rfind('.'));
 
     // Create the meta model object
-    CompositeModel theModel;
+    omtlm_CompositeModel theModel;
 
     {
         // Create model reader for the model

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -75,7 +75,7 @@ struct Color {
 
 class CompositeModelProxy {
 public:
-  CompositeModel *mpCompositeModel = 0;
+  omtlm_CompositeModel *mpCompositeModel = 0;
   double startTime = 0;
   double stopTime = 1;
   int logLevel = 0;
@@ -177,7 +177,7 @@ void checkPortAvailability(int &port) {
 }
 
 
-TLMPlugin* InitializeTLMConnection(CompositeModel& model, std::string& serverName) {
+TLMPlugin* InitializeTLMConnection(omtlm_CompositeModel& model, std::string& serverName) {
   TLMPlugin* TLMlink = MonitoringPluginImplementer::CreateInstance();
 
   std::cout << "Trying to register TLM monitor on host " << serverName << "\n";
@@ -223,7 +223,7 @@ TLMPlugin* InitializeTLMConnection(CompositeModel& model, std::string& serverNam
 
 //! Evaluate the data needed for the current time step.
 void MonitorTimeStep(TLMPlugin* TLMlink,
-                     CompositeModel& model,
+                     omtlm_CompositeModel& model,
                      double SimTime,
                      std::map<int, TLMTimeDataSignal>& dataStorageSignal,
                      std::map<int, TLMTimeData1D>& dataStorage1D,
@@ -291,7 +291,7 @@ void MonitorTimeStep(TLMPlugin* TLMlink,
   }
 }
 
-void WriteVisualXMLFile(CompositeModel& model, std::string &baseFileName, std::string &path) {
+void WriteVisualXMLFile(omtlm_CompositeModel& model, std::string &baseFileName, std::string &path) {
   // Get data from TLM-Manager here!
   bool canWriteVisualXMLFile = false;
   int nTLMComponents = model.GetComponentsNum();
@@ -545,7 +545,7 @@ void WriteVisualXMLFile(CompositeModel& model, std::string &baseFileName, std::s
   }
 }
 
-void PrintHeader(CompositeModel& model, std::ofstream& dataFile) {
+void PrintHeader(omtlm_CompositeModel& model, std::ofstream& dataFile) {
   // Get data from TLM-Manager here!
   int nTLMInterfaces = model.GetInterfacesNum();
 
@@ -620,7 +620,7 @@ void PrintHeader(CompositeModel& model, std::ofstream& dataFile) {
   dataFile << std::endl;
 }
 
-void PrintData(CompositeModel& model,
+void PrintData(omtlm_CompositeModel& model,
                std::ofstream& dataFile,
                std::map<int, TLMTimeDataSignal> &dataStorageSignal,
                std::map<int, TLMTimeData1D>& dataStorage1D,
@@ -784,7 +784,7 @@ void PrintData(CompositeModel& model,
   dataFile << std::endl;
 }
 
-void PrintRunStatus(CompositeModel& model, std::ofstream& runFile, tTM_Info& tInfo, double SimTime)  {
+void PrintRunStatus(omtlm_CompositeModel& model, std::ofstream& runFile, tTM_Info& tInfo, double SimTime)  {
   double startTime = model.GetSimParams().GetStartTime();
   double endTime = model.GetSimParams().GetEndTime();
   double timeStep = model.GetSimParams().GetWriteTimeStep();
@@ -822,7 +822,7 @@ int startMonitor(double timeStep,
                  double nSteps,
                  std::string server,
                  std::string modelName,
-                 CompositeModel &model) {
+                 omtlm_CompositeModel &model) {
 
   TLMErrorLog::Info("Starting monitoring...");
   std::cout << "Monitoring server = " << server << "\n";
@@ -929,7 +929,7 @@ int startMonitor(double timeStep,
 
 
 // Print all interfaces position and orientation
-void PrintInterfaceInformation(CompositeModel& theModel) {
+void PrintInterfaceInformation(omtlm_CompositeModel& theModel) {
   std::ofstream interfacefile ("interfaceData.xml");
   if(interfacefile.is_open()) {
     interfacefile << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
@@ -1005,7 +1005,7 @@ void PrintInterfaceInformation(CompositeModel& theModel) {
 int startManager(int serverPort,
                  int monitorPort,
                  ManagerCommHandler::CommunicationMode comMode,
-                 CompositeModel &model) {
+                 omtlm_CompositeModel &model) {
 
   std::cout << "Number of components (manager): " << model.GetComponentsNum() << "\n";
 
@@ -1071,7 +1071,7 @@ void simulateInternal(void *pModel,
   }
 
 
-  CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
+  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
 
   pCompositeModel->CheckTheModel();
 
@@ -1121,7 +1121,7 @@ void *loadModelInternal(const char *fileName,
                         const char *singleModel) {
   // Load composite model for manager
   // Note: Skip loading connections in interface request mode in case an interface no longer exists
-  CompositeModel *pCompositeModel = new CompositeModel();
+  omtlm_CompositeModel *pCompositeModel = new omtlm_CompositeModel();
   {
     CompositeModelReader managerModelReader(*pCompositeModel);
     std::string fileNameStr(fileName);
@@ -1136,14 +1136,14 @@ void *loadModelInternal(const char *fileName,
 
 void *omtlm_loadModel(const char *filename) {
   CompositeModelProxy *pModelProxy = new CompositeModelProxy();
-  pModelProxy->mpCompositeModel = (CompositeModel*)loadModelInternal(filename, false, "");
+  pModelProxy->mpCompositeModel = (omtlm_CompositeModel*)loadModelInternal(filename, false, "");
   return pModelProxy;
 }
 
 
 void *omtlm_newModel(const char *name) {
   CompositeModelProxy *pModelProxy = new CompositeModelProxy();
-  pModelProxy->mpCompositeModel = new CompositeModel();
+  pModelProxy->mpCompositeModel = new omtlm_CompositeModel();
   pModelProxy->mpCompositeModel->SetModelName(name);
   return pModelProxy;
 }
@@ -1156,13 +1156,12 @@ void omtlm_addSubModel(void *pModel,
                                  const char* file,
                                  const char* startCommand) {
   CompositeModelProxy *pModelProxy = (CompositeModelProxy*)pModel;
-  CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
+  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
   int id = pCompositeModel->RegisterTLMComponentProxy(name,
                                                       startCommand,
                                                       file,
                                                       false,
                                                       "");
-
   subModelMap.insert(std::pair<std::string,int>(std::string(name),id));
 }
 
@@ -1176,7 +1175,7 @@ void omtlm_addInterface(void *pModel,
                                   const char* causality,
                                   const char* domain) {
   CompositeModelProxy *pModelProxy = (CompositeModelProxy*)pModel;
-  CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
+  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
   std::string nameStr(name);
   int subModelId= subModelMap.find(std::string(subModelName))->second;
   int id = pCompositeModel->RegisterTLMInterfaceProxy(subModelId,
@@ -1192,19 +1191,19 @@ void omtlm_addInterface(void *pModel,
 
 
 void omtlm_addConnection(void *pModel,
-                                   const char *interfaceName1,
-                                   const char *interfaceName2,
-                                   double delay,
-                                   double Zf,
-                                   double Zfr,
-                                   double alpha) {
+                         const char *interfaceName1,
+                         const char *interfaceName2,
+                         double delay,
+                         double Zf,
+                         double Zfr,
+                         double alpha) {
   // Todo: Error checking
 
   int interfaceId1 = interfaceMap.find(std::string(interfaceName1))->second;
   int interfaceId2 = interfaceMap.find(std::string(interfaceName2))->second;
 
   CompositeModelProxy *pModelProxy = (CompositeModelProxy*)pModel;
-  CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
+  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
   TLMConnectionParams params;
   params.Delay = delay;
   params.Zf = Zf;
@@ -1232,7 +1231,7 @@ void omtlm_addParameter(void *pModel,
                                   const char *name,
                                   const char *defaultValue) {
   CompositeModelProxy *pModelProxy = (CompositeModelProxy*)pModel;
-  CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
+  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
   std::string nameStr(name);
   std::string defaultStr(defaultValue);
   int subModelId = subModelMap.find(std::string(subModelName))->second;
@@ -1252,7 +1251,7 @@ void omtlm_unloadModel(void *pModel)
   }
 
   CompositeModelProxy *pModelProxy = (CompositeModelProxy*)pModel;
-  CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
+  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
   delete pCompositeModel;
   delete pModelProxy;
 }
@@ -1269,7 +1268,7 @@ void omtlm_setStartTime(void *pModel, double startTime)
   pModelProxy->startTime = startTime;
 
   double stopTime = pModelProxy->stopTime;
-  CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
+  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
   pCompositeModel->GetSimParams().Set(11111,startTime,stopTime);
 
   double writeTimeStep = (stopTime-startTime)/1000.0;
@@ -1283,7 +1282,7 @@ void omtlm_setStopTime(void *pModel, double stopTime)
   pModelProxy->stopTime = stopTime;
 
   double startTime = pModelProxy->startTime;
-  CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
+  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
   pCompositeModel->GetSimParams().Set(11111,startTime,stopTime);
 
   double writeTimeStep = (stopTime-startTime)/1000.0;


### PR DESCRIPTION
Both OMSimulator and OMTLMSimualtor have classes named "CompositeModel". When dynamically linking OMTLMSimulator to OMSimulator, the class names will collide.

Perhaps a namespace would be better, but this works for now.