### PR TITLE
Avoid print to std output and compile on MSVC

### DIFF
--- a/FMIWrapper/FMILibrary-2.0.1/ThirdParty/c99_snprintf/CMakeLists.txt
+++ b/FMIWrapper/FMILibrary-2.0.1/ThirdParty/c99_snprintf/CMakeLists.txt
@@ -87,8 +87,8 @@ foreach(check ${CHECKS})
     endif()
 endforeach()
 add_definitions(
-    -Dvsnprintf=rpl_vsnprintf
-    -Dsnprintf=rpl_snprintf
+#    -Dvsnprintf=rpl_vsnprintf
+#    -Dsnprintf=rpl_snprintf
     -Dvasprintf=rpl_vasprintf
     -Dasprintf=rpl_asprintf
     ${DEFINES})

--- a/FMIWrapper/FMILibrary-2.0.1/ThirdParty/c99_snprintf/c99-snprintf_1.1/configure
+++ b/FMIWrapper/FMILibrary-2.0.1/ThirdParty/c99_snprintf/c99-snprintf_1.1/configure
@@ -4475,7 +4475,7 @@ _ACEOF
 else
 
 cat >>confdefs.h <<\_ACEOF
-#define vsnprintf rpl_vsnprintf
+# #define vsnprintf rpl_vsnprintf
 _ACEOF
 
 

--- a/FMIWrapper/FMILibrary-2.0.1/ThirdParty/c99_snprintf/c99-snprintf_1.1/snprintf.c
+++ b/FMIWrapper/FMILibrary-2.0.1/ThirdParty/c99_snprintf/c99-snprintf_1.1/snprintf.c
@@ -269,8 +269,8 @@
 #define HAVE___VA_COPY 1
 #endif	/* !defined(HAVE___VA_COPY) */
 #endif	/* HAVE_CONFIG_H */
-#define snprintf rpl_snprintf
-#define vsnprintf rpl_vsnprintf
+//#define snprintf rpl_snprintf
+//#define vsnprintf rpl_vsnprintf
 #define asprintf rpl_asprintf
 #define vasprintf rpl_vasprintf
 #endif	/* TEST_SNPRINTF */

--- a/FMIWrapper/Makefile
+++ b/FMIWrapper/Makefile
@@ -114,16 +114,18 @@ default: dirs
 	$(MAKE) $(ABIOBJS)
 	$(LINK) $(ABIOBJS$) -o $(ABI)/$(BNAME) $(LIBS)
 
-copyfiles:
+
+install: default
 	cp $(ABI)/$(BNAME) $(BINDIR)
 	cp StartTLMFmiWrapper* $(BINDIR)
 
-install: | default copyfiles
 
 wrapper: dirs $(ABIOBJS)
 	$(LINK) $(ABIOBJS$) -o $(ABI)/$(BNAME) $(LIBS)
 
-wrapper_install: | wrapper copyfiles
+wrapper_install: wrapper
+	cp $(ABI)/$(BNAME) $(BINDIR)
+	cp StartTLMFmiWrapper* $(BINDIR)
 
 
 .PHONY: dirs clean
@@ -138,7 +140,7 @@ dirs:
 
 fmil:
 	mkdir -p FMILibrary-2.0.1/build
-	(cd FMILibrary-2.0.1/build && $(CMAKE) -D CMAKE_AR:String="$(AR)" $(FMIL_FLAGS) -D FMILIB_BUILD_TESTS:Bool=OFF -D FMILIB_GENERATE_DOXYGEN_DOC:Bool=OFF -DFMILIB_INSTALL_PREFIX:String=../install .. -G $(CMAKE_TARGET))
+	(cd FMILibrary-2.0.1/build && $(CMAKE) $(FMIL_FLAGS) -D FMILIB_BUILD_TESTS:Bool=OFF -D FMILIB_GENERATE_DOXYGEN_DOC:Bool=OFF -DBUILD_TESTING:BOOL=0 -DFMILIB_BUILD_BEFORE_TESTS:BOOL=0 -DFMILIB_INSTALL_PREFIX:String=../install .. $(CMAKE_TARGET))
 	$(MAKE) -C FMILibrary-2.0.1/build
 	$(MAKE) -C FMILibrary-2.0.1/build install
 	cp -p FMILibrary-2.0.1/install/lib/libfmilib_shared$(SHREXT) $(BINDIR)

--- a/FMIWrapper/Makefile.msvc
+++ b/FMIWrapper/Makefile.msvc
@@ -1,0 +1,120 @@
+BINDIR=../bin/
+BUILDDIR=build\win
+TARGETDIR=..\bin
+
+CC=cl /DMSC_VER /DWIN32 /D_WIN32 /EHsc /DNOMINMAX /GR /DUSE_THREADS /MP /c 
+cc=cl
+LINK=link
+
+BNAME=FMIWrapper.exe
+MISCHOME=../3rdParty/misc
+
+INCLUDES= /I. \
+	/I"../FMIWrapper" \
+    /I"FMILibrary-2.0.1/src/Import/include" \
+    /I"FMILibrary-2.0.1/install/include" \
+	/I"../common" \
+	/I"../3rdParty/misc/include" \
+	/I"cvode-2.9.0/include" \
+	/I"ida-2.9.0/include"
+    
+LIBS= \
+ FMILibrary-2.0.1/install/lib/fmilib_shared.lib \
+ ws2_32.lib
+
+SRC= main.cpp \
+	../common/Plugin/PluginImplementer.cc \
+	../common/Communication/TLMClientComm.cc \
+	../common/Communication/TLMCommUtil.cc \
+	../common/Interfaces/TLMInterface.cc \
+	../common/Interfaces/TLMInterfaceSignal.cc \
+	../common/Interfaces/TLMInterfaceSignalInput.cc \
+	../common/Interfaces/TLMInterfaceSignalOutput.cc \
+	../common/Interfaces/TLMInterface1D.cc \
+	../common/Interfaces/TLMInterface3D.cc \
+	../common/Parameters/ComponentParameter.cc \
+	../common/Logging/TLMErrorLog.cc \
+	../common/Plugin/TLMPlugin.cc \
+	../3rdParty/misc/src/coordTransform.cc \
+	../3rdParty/misc/src/double3.cc \
+	../3rdParty/misc/src/double33.cc \
+	../3rdParty/misc/src/ErrorLog.cc \
+	../3rdParty/misc/src/double33s.cc \
+	../3rdParty/misc/src/dsyevq3.cc \
+	../3rdParty/misc/src/dsyevv3.cc \
+	../3rdParty/misc/src/dsyevc3.cc \
+	../3rdParty/misc/src/dsytrd3.cc \
+	../3rdParty/misc/src/Bstring.cc \
+	../3rdParty/misc/src/tostr.cc \
+	cvode-2.9.0/src/nvec_ser/nvector_serial.c \
+	cvode-2.9.0/src/sundials/sundials_math.c \
+	cvode-2.9.0/src/sundials/sundials_nvector.c \
+	cvode-2.9.0/src/sundials/sundials_direct.c \
+	cvode-2.9.0/src/sundials/sundials_dense.c \
+	cvode-2.9.0/src/cvode/cvode.c \
+	cvode-2.9.0/src/cvode/cvode_dense.c \
+	cvode-2.9.0/src/cvode/cvode_direct.c \
+	cvode-2.9.0/src/cvode/cvode_io.c \
+	ida-2.9.0/src/ida/ida.c \
+	ida-2.9.0/src/ida/ida_dense.c \
+	ida-2.9.0/src/ida/ida_direct.c \
+	ida-2.9.0/src/ida/ida_io.c
+
+OBJ=  $(BUILDDIR)/main.obj \
+	$(BUILDDIR)/PluginImplementer.obj \
+	$(BUILDDIR)/TLMClientComm.obj \
+	$(BUILDDIR)/TLMCommUtil.obj \
+	$(BUILDDIR)/TLMInterface.obj \
+	$(BUILDDIR)/TLMInterfaceSignal.obj \
+	$(BUILDDIR)/TLMInterfaceSignalInput.obj \
+	$(BUILDDIR)/TLMInterfaceSignalOutput.obj \
+	$(BUILDDIR)/TLMInterface1D.obj \
+	$(BUILDDIR)/TLMInterface3D.obj \
+	$(BUILDDIR)/ComponentParameter.obj \
+	$(BUILDDIR)/TLMErrorLog.obj \
+	$(BUILDDIR)/TLMPlugin.obj \
+	$(BUILDDIR)/coordTransform.obj \
+	$(BUILDDIR)/double3.obj \
+	$(BUILDDIR)/double33.obj \
+	$(BUILDDIR)/ErrorLog.obj \
+	$(BUILDDIR)/double33s.obj \
+	$(BUILDDIR)/dsyevq3.obj \
+	$(BUILDDIR)/dsyevv3.obj \
+	$(BUILDDIR)/dsyevc3.obj \
+	$(BUILDDIR)/dsytrd3.obj \
+	$(BUILDDIR)/Bstring.obj \
+	$(BUILDDIR)/tostr.obj \
+	$(BUILDDIR)/nvector_serial.obj \
+	$(BUILDDIR)/sundials_math.obj \
+	$(BUILDDIR)/sundials_nvector.obj \
+	$(BUILDDIR)/sundials_direct.obj \
+	$(BUILDDIR)/sundials_dense.obj \
+	$(BUILDDIR)/cvode.obj \
+	$(BUILDDIR)/cvode_dense.obj \
+	$(BUILDDIR)/cvode_direct.obj \
+	$(BUILDDIR)/cvode_io.obj \
+	$(BUILDDIR)/ida.obj \
+	$(BUILDDIR)/ida_dense.obj \
+	$(BUILDDIR)/ida_direct.obj \
+	$(BUILDDIR)/ida_io.obj
+   
+default: dirs link 
+ -move FMIWrapper.exe $(TARGETDIR)
+  
+dirs: $(BUILDDIR)
+
+$(BUILDDIR):
+ -mkdir $(BUILDDIR)
+ 
+link: $(OBJ)
+ $(LINK) $(OBJ) $(LIBS) /OUT:FMIWrapper.exe
+  
+$(OBJ): $(SRC)
+ $(CC) $(SRC) $(INCLUDES) /c
+ -xcopy *.obj $(BUILDDIR)
+ -del *.obj
+ 
+clean:
+ -del $(BUILDDIR)\*.obj
+ -del $(TARGETDIR)\FMIWrapper.exe
+  

--- a/FMIWrapper/StartTLMFmiWrapper
+++ b/FMIWrapper/StartTLMFmiWrapper
@@ -37,7 +37,7 @@ fi
 mkdir -p $MODELDIR
 cd $MODELDIR
 
-echo Starting an FMIWrapper simulation with input file: $6 > $NAME.simlog
+echo Starting an FMIWrapper simulation with input file: $6 >> $NAME.simlog
 echo execution directory is $MODELDIR >> $NAME.simlog
 echo Make sure that: >> $NAME.simlog
 echo time = $2 >> $NAME.simlog

--- a/FMIWrapper/StartTLMFmiWrapper
+++ b/FMIWrapper/StartTLMFmiWrapper
@@ -34,26 +34,26 @@ if [ ! -f "$MODELPATH" ] ; then
 	exit 1
 fi
 
-mkdir $MODELDIR
-echo execution directory is $MODELDIR
+mkdir -p $MODELDIR
 cd $MODELDIR
 
-echo Starting an FMIWrapper simulation with input file: $6
-echo Make sure that: 
-echo time = $2
-echo timeEnd = $3
-echo MaxTimeStep "<"= $4
-echo 
+echo Starting an FMIWrapper simulation with input file: $6 > $NAME.simlog
+echo execution directory is $MODELDIR >> $NAME.simlog
+echo Make sure that: >> $NAME.simlog
+echo time = $2 >> $NAME.simlog
+echo timeEnd = $3 >> $NAME.simlog
+echo MaxTimeStep "<"= $4 >> $NAME.simlog
+echo >> $NAME.simlog
 
-echo Writing caseID $NAME and server name $5 to file $TLMCONFIGFILE
-echo $1 > $TLMCONFIGFILE 
+echo Writing caseID $NAME and server name $5 to file $TLMCONFIGFILE >> $NAME.simlog
+echo $1 > $TLMCONFIGFILE
 echo $5 >> $TLMCONFIGFILE
 echo $2 >> $TLMCONFIGFILE
 echo $3 >> $TLMCONFIGFILE
 echo $4 >> $TLMCONFIGFILE
 
-echo Starting FMIWrapper
-echo $FMIWrapper_Cmd
-echo DOING THIS: $FMIWrapper_Cmd > $NAME.simlog
+echo Starting FMIWrapper >> $NAME.simlog
+echo $FMIWrapper_Cmd >> $NAME.simlog
+echo DOING THIS: $FMIWrapper_Cmd >> $NAME.simlog
 $FMIWrapper_Cmd
-echo DONE THIS: $FMIWrapper_Cmd > $NAME.simlog
+echo DONE THIS: $FMIWrapper_Cmd >> $NAME.simlog

--- a/FMIWrapper/buildWinVS.bat
+++ b/FMIWrapper/buildWinVS.bat
@@ -1,0 +1,81 @@
+@ECHO OFF
+REM Bat script building FMILibrary dependency automatically
+REM Author: Robert Braun robert.braun@liu.se
+REM Date:   2016-09-26
+REM Note:   Based on scripts for Hopsan depencencies by Peter Nordin
+
+REM Argument %1 should be architecture: x86 or x64
+
+REM Default values. Use x64 for 64-bit, use x86 for 32-bit
+set arch=x64
+
+if not "%~1"=="" (
+	set arch=%~2
+)
+
+echo Setting paths for Version: %1, Architecture: %arch%
+
+
+set mingw_path32=C:\Qt\Tools\mingw491_32\bin
+set mingw_path64=C:\Qt\x86_64-4.9.3-release-posix-seh-rt_v4-rev1\mingw64\bin
+
+
+if not "%arch%"=="x86" (
+  if not "%arch%"=="x64" (
+	echo Error: arch must be x86 or x64
+	pause
+	goto :eof
+  )
+)
+
+REM Tools paths
+set cmake_path32=%ProgramFiles%\CMake\bin
+set cmake_path64=%ProgramFiles(x86)%\CMake\bin
+set msys_path=C:\msys64\usr\bin
+
+REM Set tools paths depending on current arch
+if defined ProgramFiles(x86) (
+	REM do stuff for 64bit here
+	echo 64bit Windows detected, expecting 64-bit tools
+	set "cmake_path=%cmake_path64%"
+) else (
+    REM do stuff for 32bit here
+	echo 32bit Windows detected, expecting 32-bit tools
+	set "cmake_path=%cmake_path32%"
+)
+
+REM Set compilers and libs depending on selection
+if "%arch%"=="x64" (
+	set "mingw_path=%mingw_path64%"
+) else (
+	set "mingw_path=%mingw_path32%"
+)
+
+REM Echo resulting paths
+echo CMake path:   %cmake_path%
+echo Msys path:    %msys_path%
+echo MinGW path:   %mingw_path%
+
+echo.
+
+set PATH=%mingw_path%;%cmake_path%;%PATH%
+
+set dirname=FMILibrary-2.0.1
+
+REM Build
+echo.
+echo ======================
+echo Building 64-bit version of FMILibrary
+echo ======================
+cd %dirname%
+mkdir build-fmilib
+cd build-fmilib
+cmake -Wno-dev -G "MinGW Makefiles" -DFMILIB_FMI_PLATFORM="win64" ../
+mingw32-make.exe -j4 -B
+mingw32-make.exe install
+
+xcopy    libfmilib_shared.dll ..\..\..\bin
+
+echo.
+echo Done
+pause

--- a/FMIWrapper/main.cpp
+++ b/FMIWrapper/main.cpp
@@ -1344,8 +1344,6 @@ int main(int argc, char* argv[])
 
   std::string path, file;
   splitPathAndFilename(argv[2], path, file);
-  cout << "name = " << argv[1] << "\n";
-  cout << "path = " << argv[2] << "\n";
 
   std::string name = argv[1];
   std::string FMUPath = argv[2];
@@ -1368,7 +1366,7 @@ int main(int argc, char* argv[])
       simConfig.solver = IDA;
     else if(!strcmp(argv[i],"-d")) {
       TLMErrorLog::SetLogLevel(TLMLogLevel::Debug);
-      cout << "Activating debug output" << endl;
+      //cout << "Activating debug output" << endl;
     }
     else if(!strcmp(argv[i],"-l") && argc > i+1) {
       int logLevel = atoi(argv[i+1]);

--- a/FMIWrapper/main.cpp
+++ b/FMIWrapper/main.cpp
@@ -1,3 +1,5 @@
+#define _WINSOCKAPI_
+
 // C++ includes
 #include <iostream>
 #include <string>
@@ -6,7 +8,9 @@
 #include <sys/stat.h>
 #include <cstdio>
 #include <cstdlib>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <vector>
 #include <fstream>
 #include <map>

--- a/Makefile.head
+++ b/Makefile.head
@@ -22,7 +22,7 @@ ifeq ($(ABI),WINDOWS64)
     SHREXT=.dll
     OMDEVMSYS=$(shell cygpath $$OMDEV)
     CMAKE = $(OMDEVMSYS)/bin/cmake/bin/cmake
-    CMAKE_TARGET="MSYS Makefiles"
+    CMAKE_TARGET=-G "MSYS Makefiles"
     FMIL_FLAGS=-DFMILIB_FMI_PLATFORM=win64
   else
     CC=mycl cl64 /DMSC_VER /DWIN32 /D_WIN32 /EHsc /DNOMINMAX /GR
@@ -43,7 +43,7 @@ else ifeq ($(ABI),WINDOWS32)
     SHREXT=.dll
     OMDEVMSYS=$(shell cygpath $$OMDEV)
     CMAKE = $(OMDEVMSYS)/bin/cmake/bin/cmake
-    CMAKE_TARGET="MSYS Makefiles"
+    CMAKE_TARGET=-G "MSYS Makefiles"
     FMIL_FLAGS=-DFMILIB_FMI_PLATFORM=win32
   else
     $(error No compiler found to build for WINDOWS32)
@@ -56,7 +56,7 @@ else ifeq ($(ABI),MAC64)
     CP=cp
     SHREXT=.dylib
     CMAKE=cmake
-    CMAKE_TARGET="Unix Makefiles"
+    CMAKE_TARGET="-G Unix Makefiles"
     FMIL_FLAGS=
 else
     CC=g++
@@ -66,7 +66,7 @@ else
     CP=cp
     SHREXT=.so
     CMAKE=cmake
-    CMAKE_TARGET="Unix Makefiles"
+    CMAKE_TARGET="-GUnix Makefiles"
     FMIL_FLAGS=
 endif
 

--- a/buildWinVS.bat
+++ b/buildWinVS.bat
@@ -1,3 +1,12 @@
+@ECHO off
+
+SET OMS_VS_TARGET=%~1
+IF ["%OMS_VS_TARGET%"]==["VS14-Win32"] SET OMS_VS_PLATFORM=32 && SET OMS_VS_VERSION="Visual Studio 14 2015"
+IF ["%OMS_VS_TARGET%"]==["VS14-Win64"] SET OMS_VS_PLATFORM=64 && SET OMS_VS_VERSION="Visual Studio 14 2015 Win64"
+IF ["%OMS_VS_TARGET%"]==["VS15-Win64"] SET OMS_VS_PLATFORM=64 && SET OMS_VS_VERSION="Visual Studio 15 2017 Win64"
+
+echo %OMS_VS_TARGET% %OMS_VS_VERSION%
+
 cd 3rdParty\misc
 echo Building 3rdParty\misc
 nmake -f Makefile.msvc
@@ -7,5 +16,16 @@ nmake -f Makefile.msvc
 cd ..\..\common
 echo Building common
 nmake -f Makefile.msvc
+cd ..\FMIWrapper\FMILibrary-2.0.1
+mkdir build-fmilib
+cd build-fmilib
+cmake -DHAVE_SNPRINTF=1 -DHAVE_VSNPRINTF=1 -G %OMS_VS_VERSION% ../
+cmake --build . --config MinSizeRel --target install
+xcopy install/bin/fmilib_shared.dll ..\..\..\bin
+xcopy install/bin/fmilib_shared.dll ..\..\..\..\lib
+cd ../../
+nmake -f Makefile.msvc
+xcopy ..\..\bin\FMIWrapper ..\..\..\bin
 cd ..
+
 EXIT /B

--- a/common/Logging/TLMErrorLog.cc
+++ b/common/Logging/TLMErrorLog.cc
@@ -86,7 +86,7 @@ void TLMErrorLog::FatalError(const std::string& mess) {
 void  TLMErrorLog::Warning(const std::string& mess) {
     if(LogLevel < TLMLogLevel::Warning) return;
     Open();
-    std::cout << TimeStr() << " Warning: " << mess << std::endl;
+    //std::cout << TimeStr() << " Warning: " << mess << std::endl;
     *outStream << TimeStr() << " Warning: " << mess << std::endl;
 
     if(NormalErrorLogOn) {


### PR DESCRIPTION
Print most output to logfile, to make std output cleaner, and to make it work with the testsuite.

Also fixed compilaton of FMIWrapper on MSVC.