### PR TITLE
Renamed TLMInterface to omtlm_TLMInterface

### DIFF
--- a/common/Communication/ManagerCommHandler.cc
+++ b/common/Communication/ManagerCommHandler.cc
@@ -19,6 +19,7 @@
 #include <unistd.h> 
 #endif
 
+
 using std::string;
 using std::cerr;
 using std::endl;
@@ -106,6 +107,7 @@ void ManagerCommHandler::RunStartupProtocol() {
     tTM_Info tInfo;
     TM_Init(&tInfo);
     TM_Start(&tInfo);
+
 
     while((numToRegister > 0) || (numCheckModel < TheModel.GetComponentsNum())) {
         Comm.SelectReadSocket();

--- a/common/Communication/ManagerCommHandler.h
+++ b/common/Communication/ManagerCommHandler.h
@@ -118,7 +118,7 @@ public:
     //! RunStartupProtocol implements startup protocol that
     //! enables client registration at the manager
     void RunStartupProtocol();
-    
+
 
     //! ProcessRegComponentMessage processes the first message after "accept"
     //! It is expected to be a component registration message.

--- a/common/Communication/TLMClientComm.cc
+++ b/common/Communication/TLMClientComm.cc
@@ -7,7 +7,6 @@
 #include "Communication/TLMClientComm.h"
 #include "Logging/TLMErrorLog.h"
 #include "Interfaces/TLMInterface.h"
-#include "tostr.h"
 #include <vector>
 #include <deque>
 #include <string>
@@ -29,6 +28,7 @@ using std::string;
 #include <arpa/inet.h>
 #else
 #include <winsock2.h>
+#define NOMINMAX
 #include <windows.h>
 #include <cassert>
 #include <io.h>
@@ -290,9 +290,9 @@ void TLMClientComm::UnpackRegInterfaceMessage(TLMMessage& mess, TLMConnectionPar
     if(mess.Header.DataSize == 0) return; // non connected interface
     if(mess.Header.DataSize != sizeof(TLMConnectionParams)) {
         TLMErrorLog::FatalError("Wrong size of message in interface registration : DataSize "+
-            Int2Str(mess.Header.DataSize)+
+            std::to_string(mess.Header.DataSize)+
             " sizeof(TLMConnectionParams)="+
-            Int2Str(sizeof(TLMConnectionParams)));
+            std::to_string(sizeof(TLMConnectionParams)));
     }
 
     // check if we have byte order missmatch in the message and perform
@@ -313,9 +313,9 @@ void TLMClientComm::UnpackRegParameterMessage(TLMMessage &mess, std::string &Val
     char ValueBuf[100];
     if(mess.Header.DataSize != sizeof(ValueBuf)) {
         TLMErrorLog::FatalError("Wrong size of message in parameter registration : DataSize "+
-            Int2Str(mess.Header.DataSize)+
+            std::to_string(mess.Header.DataSize)+
             " sizeof(ValueBuf)="+
-            Int2Str(sizeof(ValueBuf)));
+            std::to_string(sizeof(ValueBuf)));
     }
 
     // check if we have byte order missmatch in the message and perform

--- a/common/Communication/TLMCommUtil.cc
+++ b/common/Communication/TLMCommUtil.cc
@@ -1,6 +1,5 @@
 #include "Communication/TLMCommUtil.h"
 #include "Logging/TLMErrorLog.h"
-#include "tostr.h"
 
 #include <string>
 
@@ -32,8 +31,8 @@ void TLMCommUtil::SendMessage(TLMMessage& mess) {
 
     if(doDetailedLogging) {
         TLMErrorLog::Info("SendMessage: wants to send "+
-                         Int2Str(sizeof(TLMMessageHeader))+"+"+
-                         Int2Str(DataSize)+ " bytes ");
+                         std::to_string(sizeof(TLMMessageHeader))+"+"+
+                         std::to_string(DataSize)+ " bytes ");
     }
 
     if(TLMMessageHeader::IsBigEndianSystem != mess.Header.SourceIsBigEndianSystem) {
@@ -57,11 +56,11 @@ void TLMCommUtil::SendMessage(TLMMessage& mess) {
 
 #ifdef  WIN32
     int errcode = WSAGetLastError();
-    if(errcode) TLMErrorLog::Warning("send() SOCKET_ERROR received, error code ="+Int2Str(errcode));
+    if(errcode) TLMErrorLog::Warning("send() SOCKET_ERROR received, error code ="+std::to_string(errcode));
 #endif
 
     if(doDetailedLogging) {
-        TLMErrorLog::Info("SendMessage:send() sent "+Int2Str(sendBytes)+ " bytes ");
+        TLMErrorLog::Info("SendMessage:send() sent "+std::to_string(sendBytes)+ " bytes ");
     }
 
     if(DataSize > 0) {
@@ -74,11 +73,11 @@ void TLMCommUtil::SendMessage(TLMMessage& mess) {
 
 #ifdef  WIN32
         int errcode = WSAGetLastError();
-        if(errcode) TLMErrorLog::Warning("send() SOCKET_ERROR received, error code ="+Int2Str(errcode));
+        if(errcode) TLMErrorLog::Warning("send() SOCKET_ERROR received, error code ="+std::to_string(errcode));
 #endif
 
         if(doDetailedLogging) {
-            TLMErrorLog::Info("SendMessage:send()(part 2) sent "+Int2Str(sendBytes)+ " bytes ");
+            TLMErrorLog::Info("SendMessage:send()(part 2) sent "+std::to_string(sendBytes)+ " bytes ");
         }
 
     }
@@ -118,14 +117,14 @@ bool TLMCommUtil::ReceiveMessage(TLMMessage& mess) {
         int errcode=WSAGetLastError();
         if(errcode==WSAECONNRESET)
             // This is called by normal termination of BEAST
-            TLMErrorLog::Info("SOCKET_ERROR received, error code ="+Int2Str(errcode));
+            TLMErrorLog::Info("SOCKET_ERROR received, error code ="+std::to_string(errcode));
         else
-            TLMErrorLog::Warning("SOCKET_ERROR received, error code ="+Int2Str(errcode));
+            TLMErrorLog::Warning("SOCKET_ERROR received, error code ="+std::to_string(errcode));
 #endif
         return false;
     }
     if(doDetailedLogging) {
-        TLMErrorLog::Info("ReceiveMessage:recv() returned "+Int2Str(bcount)+ " bytes ");
+        TLMErrorLog::Info("ReceiveMessage:recv() returned "+std::to_string(bcount)+ " bytes ");
     }
 
     if(strncmp(mess.Header.Signature, TLMMessageHeader::TLMSignature, TLMMessageHeader::TLM_SIGNATURE_LENGTH) != 0) {
@@ -169,13 +168,13 @@ bool TLMCommUtil::ReceiveMessage(TLMMessage& mess) {
 
 #ifdef  WIN32
             int errcode=WSAGetLastError();
-            TLMErrorLog::Warning("SOCKET_ERROR received(part 2), error code ="+Int2Str(errcode));
+            TLMErrorLog::Warning("SOCKET_ERROR received(part 2), error code ="+std::to_string(errcode));
 #endif
 
             return false;
         }
         if(doDetailedLogging) {
-            TLMErrorLog::Info("ReceiveMessage:recv()(part 2) returned "+Int2Str(bcount)+ " bytes ");
+            TLMErrorLog::Info("ReceiveMessage:recv()(part 2) returned "+std::to_string(bcount)+ " bytes ");
         }
         if(bcount != mess.Header.DataSize) {
             TLMErrorLog::FatalError("Error receiving message data");

--- a/common/Communication/TLMCommUtil.h
+++ b/common/Communication/TLMCommUtil.h
@@ -17,6 +17,7 @@
 
 #if defined(WIN32) || defined(__MINGW32__)
 #include <winsock2.h>
+#define NOMINMAX
 #include <windows.h>
 
 //// #define MSG_WAITALL 0

--- a/common/Communication/TLMManagerComm.cc
+++ b/common/Communication/TLMManagerComm.cc
@@ -23,6 +23,7 @@ using std::string;
 #define BCloseSocket close
 #else
 #include <winsock2.h>
+#define NOMINMAX
 #include <windows.h>
 #include <cassert>
 #include <io.h>

--- a/common/Interfaces/TLMInterface.cc
+++ b/common/Interfaces/TLMInterface.cc
@@ -22,7 +22,7 @@ using std::ofstream;
 
 
 // TLMInterface constructor
-TLMInterface::TLMInterface(TLMClientComm& theComm, std::string& aName, double StartTime,
+omtlm_TLMInterface::omtlm_TLMInterface(TLMClientComm& theComm, std::string& aName, double StartTime,
                            int dimensions, std::string causality, std::string domain):
     LastSendTime(StartTime),
     NextRecvTime(0.0),
@@ -55,12 +55,12 @@ TLMInterface::TLMInterface(TLMClientComm& theComm, std::string& aName, double St
 }
 
 
-TLMInterface::~TLMInterface() {}
+omtlm_TLMInterface::~omtlm_TLMInterface() {}
 
 
 // Hermite cubic interpolation. For the given 4 data points t[i], f[i] and time,
 // such that t[0]<t[1]<time<t[2]<t[3], returns f(time). .
-double TLMInterface::InterpolateHermite(double time, double t[4], double f[4]) {
+double omtlm_TLMInterface::InterpolateHermite(double time, double t[4], double f[4]) {
     double fa = f[1];
     double fb = f[2];
     double  ta = t[1];

--- a/common/Interfaces/TLMInterface.h
+++ b/common/Interfaces/TLMInterface.h
@@ -19,15 +19,15 @@
 //!
 //! TLMInterface provides the client side functionality for a single TLM interface
 //!
-class TLMInterface {
+class omtlm_TLMInterface {
 
 public:
 
     //! TLMInterface constructor. Sends a registration message to the TLM manager
     //! and prepares the object for simulation.
-    TLMInterface(TLMClientComm& theComm, std::string& aName, double StartTime, int dimensions=6,
+    omtlm_TLMInterface(TLMClientComm& theComm, std::string& aName, double StartTime, int dimensions=6,
                  std::string causality="Bidirecitonal", std::string domain="Mechanical");
-    virtual ~TLMInterface();
+    virtual ~omtlm_TLMInterface();
     //! Indecates if the interface is finished and waits for shutdown.
     //! This is use for interface request mode and not simulation mode.
     bool waitForShutdown() { return waitForShutdownFlg; }

--- a/common/Interfaces/TLMInterface1D.cc
+++ b/common/Interfaces/TLMInterface1D.cc
@@ -10,7 +10,7 @@
 static const double TLM_DAMP_DELAY = 1.5;
 
 TLMInterface1D::TLMInterface1D(TLMClientComm &theComm, std::string &aName, double StartTime, std::string Domain)
-    : TLMInterface(theComm, aName, StartTime, 1, "Bidirectional", Domain) {}
+    : omtlm_TLMInterface(theComm, aName, StartTime, 1, "Bidirectional", Domain) {}
 
 TLMInterface1D::~TLMInterface1D() {
     if(DataToSend.size() != 0) {
@@ -242,17 +242,17 @@ void TLMInterface1D::InterpolateLinear(TLMTimeData1D& Instance, TLMTimeData1D& p
     const double t1 = p1.time;
 
     // interpolate force "wave"
-    Instance.GenForce = TLMInterface::linear_interpolate(time, t0, t1, p0.GenForce, p1.GenForce);
+    Instance.GenForce = omtlm_TLMInterface::linear_interpolate(time, t0, t1, p0.GenForce, p1.GenForce);
 
     if(OnlyForce) return;
 
     // The rest is optional
 
     // interpolate position
-    Instance.Position = TLMInterface::linear_interpolate(time, t0, t1, p0.Position, p1.Position);
+    Instance.Position = omtlm_TLMInterface::linear_interpolate(time, t0, t1, p0.Position, p1.Position);
 
     // interpolate velocity
-    Instance.Velocity = TLMInterface::linear_interpolate(time, t0, t1, p0.Velocity, p1.Velocity);
+    Instance.Velocity = omtlm_TLMInterface::linear_interpolate(time, t0, t1, p0.Velocity, p1.Velocity);
 }
 
 

--- a/common/Interfaces/TLMInterface1D.h
+++ b/common/Interfaces/TLMInterface1D.h
@@ -17,7 +17,7 @@ class TLMTimeData1D;
 //!
 //! TLMInterface1D provides the client side functionality for a single TLM interface of one dimension
 //!
-class TLMInterface1D : public TLMInterface {
+class TLMInterface1D : public omtlm_TLMInterface {
 public:
     TLMInterface1D(TLMClientComm &theComm, std::string &aName, double StartTime, std::string Domain="Mechanical");
 

--- a/common/Interfaces/TLMInterface3D.cc
+++ b/common/Interfaces/TLMInterface3D.cc
@@ -10,7 +10,7 @@
 static const double TLM_DAMP_DELAY = 1.5;
 
 TLMInterface3D::TLMInterface3D(TLMClientComm &theComm, std::string &aName, double StartTime, std::string Domain)
-    : TLMInterface(theComm, aName, StartTime, 6, "Bidirectional", Domain) {}
+    : omtlm_TLMInterface(theComm, aName, StartTime, 6, "Bidirectional", Domain) {}
 
 TLMInterface3D::~TLMInterface3D() {
     if(DataToSend.size() != 0) {
@@ -344,7 +344,7 @@ void TLMInterface3D::InterpolateLinear(TLMTimeData3D& Instance, TLMTimeData3D& p
 
     while(j-- > 0) { // interpolate force "wave"
         Instance.GenForce[j] =
-                TLMInterface::linear_interpolate(time, t0, t1, p0.GenForce[j], p1.GenForce[j]);
+                omtlm_TLMInterface::linear_interpolate(time, t0, t1, p0.GenForce[j], p1.GenForce[j]);
     }
 
     if(OnlyForce) return;
@@ -354,13 +354,13 @@ void TLMInterface3D::InterpolateLinear(TLMTimeData3D& Instance, TLMTimeData3D& p
     j = 3;
     while(j-- > 0) { // interpolate position
         Instance.Position[j] =
-                TLMInterface::linear_interpolate(time, t0, t1, p0.Position[j], p1.Position[j]);
+                omtlm_TLMInterface::linear_interpolate(time, t0, t1, p0.Position[j], p1.Position[j]);
     }
 
     j = 6;
     while(j-- > 0) { // interpolate velocity
         Instance.Velocity[j] =
-                TLMInterface::linear_interpolate(time, t0, t1, p0.Velocity[j], p1.Velocity[j]);
+                omtlm_TLMInterface::linear_interpolate(time, t0, t1, p0.Velocity[j], p1.Velocity[j]);
     }
 
     // interpolation of angles require special treatment.
@@ -383,7 +383,7 @@ void TLMInterface3D::InterpolateLinear(TLMTimeData3D& Instance, TLMTimeData3D& p
 
     j = 4;
     while(--j > 0) {
-        phi(j) = TLMInterface::linear_interpolate(time, t0, t1, 0.0, phi(j));
+        phi(j) = omtlm_TLMInterface::linear_interpolate(time, t0, t1, 0.0, phi(j));
     }
     // now get the matrix (into A[0]):
     A0 *= A321(phi);
@@ -426,7 +426,7 @@ void TLMInterface3D::InterpolateHermite(TLMTimeData3D& Instance, std::deque<TLMT
         while(i-- > 0) {
             f[i] = p[i]->GenForce[j];
         }
-        Instance.GenForce[j] = TLMInterface::InterpolateHermite(time, t, f);
+        Instance.GenForce[j] = omtlm_TLMInterface::InterpolateHermite(time, t, f);
     }
 
     if(OnlyForce) return;
@@ -439,7 +439,7 @@ void TLMInterface3D::InterpolateHermite(TLMTimeData3D& Instance, std::deque<TLMT
         while(i-- > 0) {
             f[i] = p[i]->Position[j];
         }
-        Instance.Position[j] = TLMInterface::InterpolateHermite(time, t, f);
+        Instance.Position[j] = omtlm_TLMInterface::InterpolateHermite(time, t, f);
     }
 
     // interpolation of angles require special treatment.
@@ -473,7 +473,7 @@ void TLMInterface3D::InterpolateHermite(TLMTimeData3D& Instance, std::deque<TLMT
         while(i-- > 0) {
             f[i] = phi[i](j);
         }
-        phi_out(j) = TLMInterface::InterpolateHermite(time, t, f);
+        phi_out(j) = omtlm_TLMInterface::InterpolateHermite(time, t, f);
     }
     // now get the matrix (into A[0]):
     A[0] *= A321(phi_out);

--- a/common/Interfaces/TLMInterface3D.h
+++ b/common/Interfaces/TLMInterface3D.h
@@ -17,7 +17,7 @@ class TLMTimeData3D;
 //!
 //! TLMInterface1D provides the client side functionality for a single TLM interface of three dimensions
 //!
-class TLMInterface3D : public TLMInterface {
+class TLMInterface3D : public omtlm_TLMInterface {
 public:
     TLMInterface3D(TLMClientComm& theComm, std::string& aName, double StartTime, std::string Domain="Mechanical");
 

--- a/common/Interfaces/TLMInterfaceSignal.cc
+++ b/common/Interfaces/TLMInterfaceSignal.cc
@@ -12,7 +12,7 @@ static const double TLM_DAMP_DELAY = 1.5;
 TLMInterfaceSignal::TLMInterfaceSignal(TLMClientComm &theComm, std::string &aName, double StartTime,
                                        int Dimensions, std::string Causality,
                                        std::string Domain)
-    : TLMInterface(theComm, aName, StartTime, Dimensions, Causality, Domain) {}
+    : omtlm_TLMInterface(theComm, aName, StartTime, Dimensions, Causality, Domain) {}
 
 TLMInterfaceSignal::~TLMInterfaceSignal() {}
 
@@ -147,6 +147,6 @@ void TLMInterfaceSignal::linear_interpolate(TLMTimeDataSignal &Instance, TLMTime
     const double t1 = p1.time;
 
     // interpolate value
-    Instance.Value = TLMInterface::linear_interpolate(time, t0, t1, p0.Value, p1.Value);
+    Instance.Value = omtlm_TLMInterface::linear_interpolate(time, t0, t1, p0.Value, p1.Value);
 }
 

--- a/common/Interfaces/TLMInterfaceSignal.h
+++ b/common/Interfaces/TLMInterfaceSignal.h
@@ -15,7 +15,7 @@
 //!
 //! TLMInterfaceSignal provides the base class for client side functionality for a single signal interface
 //!
-class TLMInterfaceSignal : public TLMInterface {
+class TLMInterfaceSignal : public omtlm_TLMInterface {
 public:
   TLMInterfaceSignal(TLMClientComm &theComm, std::string &aName, double StartTime, int Dimensions,
                      std::string Causality, std::string Domain="Signal");

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.h
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.h
@@ -28,6 +28,7 @@
 extern "C"
 {
 #endif
+
 DLLEXPORT void* omtlm_newModel(const char *name);
 
 /**
@@ -135,6 +136,8 @@ DLLEXPORT void omtlm_setLogLevel(void *pModel, int logLevel);
  * @param address IP address to where manger process is running.
  */
 DLLEXPORT void omtlm_setAddress(void *pModel, std::string address);
+
+DLLEXPORT void omtlm_checkPortAvailability(int *port);
 
 /**
  * \brief Sets manager port.

--- a/common/OMTLMSimulatorMain.cc
+++ b/common/OMTLMSimulatorMain.cc
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <sstream>
 #ifdef _WIN32
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/common/Plugin/MonitoringPluginImplementer.cc
+++ b/common/Plugin/MonitoringPluginImplementer.cc
@@ -12,7 +12,7 @@ MonitoringPluginImplementer* MonitoringPluginImplementer::CreateInstance() {
     return new MonitoringPluginImplementer();
 }
 
-void MonitoringPluginImplementer::ReceiveTimeData(TLMInterface* reqIfc, double time) {
+void MonitoringPluginImplementer::ReceiveTimeData(omtlm_TLMInterface* reqIfc, double time) {
     while(time > reqIfc->GetNextRecvTime()) { // while data is needed
 
         // Receive data untill there is info for this interface
@@ -23,7 +23,7 @@ void MonitoringPluginImplementer::ReceiveTimeData(TLMInterface* reqIfc, double t
                               TLMErrorLog::ToStdStr(time));
         }
 
-        TLMInterface* ifc = NULL;
+        omtlm_TLMInterface* ifc = NULL;
 
         do {
 

--- a/common/Plugin/MonitoringPluginImplementer.h
+++ b/common/Plugin/MonitoringPluginImplementer.h
@@ -30,7 +30,7 @@ public:
     //! Input:
     //!   reqIfc - TLM interface that triggered the request;
     //!   time - time needed
-    void ReceiveTimeData(TLMInterface *reqIfc, double time);
+    void ReceiveTimeData(omtlm_TLMInterface *reqIfc, double time);
 
     //! Initialize plugin for interface monitoring. Should be called
     //! after the default constructor. It will initialize the object

--- a/common/Plugin/PluginImplementer.cc
+++ b/common/Plugin/PluginImplementer.cc
@@ -116,7 +116,7 @@ PluginImplementer::PluginImplementer():
 
 PluginImplementer::~PluginImplementer() {
 
-    for(vector<TLMInterface*>::iterator it = Interfaces.begin();
+    for(vector<omtlm_TLMInterface*>::iterator it = Interfaces.begin();
         it != Interfaces.end(); ++it) {
         delete (*it);
     }
@@ -205,7 +205,7 @@ int  PluginImplementer::RegisteTLMInterface(std::string name , int dimensions,
                                             std::string causality, std::string domain) {
     TLMErrorLog::Info(string("Register Interface ") + name);
 
-    TLMInterface *ifc;
+    omtlm_TLMInterface *ifc;
     if(dimensions==6) {
         TLMErrorLog::Info("Registers TLM interface of type 3D");
         ifc = new TLMInterface3D(ClientComm, name, StartTime, domain);
@@ -273,7 +273,7 @@ int PluginImplementer::RegisterComponentParameter(std::string name, std::string 
 // before the desired message is received.
 // Input:
 //   interfaceID - ID of a TLM interface that triggered the request
-void PluginImplementer::ReceiveTimeData(TLMInterface* reqIfc, double time) {
+void PluginImplementer::ReceiveTimeData(omtlm_TLMInterface* reqIfc, double time) {
     while(time > reqIfc->GetNextRecvTime()) { // while data is needed
 
         // Receive data untill there is info for this interface
@@ -291,7 +291,7 @@ void PluginImplementer::ReceiveTimeData(TLMInterface* reqIfc, double time) {
             break;
         }
 
-        TLMInterface* ifc = NULL;
+        omtlm_TLMInterface* ifc = NULL;
 
         do {
 
@@ -445,7 +445,7 @@ void PluginImplementer::SetMotion3D(int forceID,
     }
     else {
         // Check if all interfaces wait for shutdown
-        std::vector<TLMInterface*>::iterator iter;
+        std::vector<omtlm_TLMInterface*>::iterator iter;
         for(iter=Interfaces.begin(); iter!=Interfaces.end(); iter++) {
             if((*iter)->GetCausality() == "Input") continue;
             if(! (*iter)->waitForShutdown()) return;
@@ -480,7 +480,7 @@ void PluginImplementer::SetValueSignal(int valueID,
     }
     else {
         // Check if all interfaces wait for shutdown
-        std::vector<TLMInterface*>::iterator iter;
+        std::vector<omtlm_TLMInterface*>::iterator iter;
         for(iter=Interfaces.begin(); iter!=Interfaces.end(); iter++) {
             if((*iter)->GetCausality() == "Input") continue;
             if(! (*iter)->waitForShutdown()) return;
@@ -516,7 +516,7 @@ void PluginImplementer::SetMotion1D(int forceID,
     }
     else {
         // Check if all interfaces wait for shutdown
-        std::vector<TLMInterface*>::iterator iter;
+        std::vector<omtlm_TLMInterface*>::iterator iter;
         for(iter=Interfaces.begin(); iter!=Interfaces.end(); iter++) {
             if((*iter)->GetCausality() == "Input") continue;
             if(! (*iter)->waitForShutdown()) return;
@@ -538,7 +538,7 @@ void PluginImplementer::GetConnectionParams(int interfaceID, TLMConnectionParams
 
     // Use the ID to get to the right interface object
     int idx = GetInterfaceIndex(interfaceID);
-    TLMInterface* ifc = Interfaces[idx];
+    omtlm_TLMInterface* ifc = Interfaces[idx];
     assert(ifc -> GetInterfaceID() == interfaceID);
 
     ParamsOut = ifc->GetConnParams();

--- a/common/Plugin/PluginImplementer.h
+++ b/common/Plugin/PluginImplementer.h
@@ -50,7 +50,7 @@ protected:
     void CheckModel();
 
     //! Registered interfaces
-    std::vector<TLMInterface*> Interfaces;
+    std::vector<omtlm_TLMInterface*> Interfaces;
 
     //! Registered parameters
     std::vector<ComponentParameter*> Parameters;
@@ -104,7 +104,7 @@ protected:
     //! Input:
     //!   reqIfc - TLM interface that triggered the request;
     //!   time - time needed
-    virtual void ReceiveTimeData(TLMInterface* reqIfc, double time);
+    virtual void ReceiveTimeData(omtlm_TLMInterface* reqIfc, double time);
 
     //! Evaluate the reaction force from the TLM connection
     //! for a specified interface. Might need to receive messages from the


### PR DESCRIPTION
Renamed tlm interface class to avoid name conflict with OMSimulator.

Also made checkPortAccessibility() function available through API. It should not be executed internally, since some tools may not use the tlm.config file (for instance OMSimulator).