### PR TITLE
API for setting initial position and orientation

### DIFF
--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.h
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.h
@@ -76,6 +76,11 @@ DLLEXPORT void omtlm_addInterface(void* pModel,
                   const char *causality,
                   const char *domain);
 
+DLLEXPORT void omtlm_setInitialPositionAndOrientation(void *pModel,
+                                                      const char* interfaceName,
+                                                      std::vector<double> position,
+                                                      std::vector<double> orientation);
+
 /**
  * \brief Adds a connection between two interfaces.
  *


### PR DESCRIPTION
## Related Issues

Fixes #76

## Purpose

3D models need to set position and alignment, both for submodels and interfaces, to achieve correct alignment.

## Approach

Added API function that sets position and orientation, either for a submodel or an interface.

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings

---

## Open Questions and Pre-Merge TODOs