### PR TITLE
Link to lowercase Hopsan binaries

### DIFF
--- a/Hopsan/TLMPluginLib/hopsanDebugReleaseCompile.prf
+++ b/Hopsan/TLMPluginLib/hopsanDebugReleaseCompile.prf
@@ -1,10 +1,10 @@
 # Special options for deug and release mode
 # In debug mode HopsanCore has the debug extension _d
 CONFIG(debug, debug|release) {
-    LIBS *= -lHopsanCore_d
+    LIBS *= -lhopsancore_d
     DEFINES *= DEBUGCOMPILING
 }
 CONFIG(release, debug|release) {
-    LIBS *= -lHopsanCore
+    LIBS *= -lhopsancore
     DEFINES *= RELEASECOMPILING
 }


### PR DESCRIPTION
Hopsan binaries changed to lowercase, so build files for the wrapper needs update.