### PR TITLE
Initial flow API function

### DIFF
--- a/common/Interfaces/TLMInterface1D.cc
+++ b/common/Interfaces/TLMInterface1D.cc
@@ -183,7 +183,13 @@ void TLMInterface1D::SetTimeData(double time,
     }
 
     //Default value is the initial value
-    item.GenForce=InitialForce;
+    if(Domain == "Hydraulic") {
+      item.GenForce = InitialForce + Params.Zf*InitialFlow;
+    }
+    else {
+      item.GenForce = InitialForce - Params.Zf*InitialFlow;
+    }
+
 
     if(Domain == "Hydraulic") {
         TLMPlugin::GetForce1D(-speed, request, Params, &item.GenForce);
@@ -235,7 +241,12 @@ void TLMInterface1D::SendAllData() {
 
 void TLMInterface1D::SetInitialForce(double force)
 {
-    InitialForce = force;
+  InitialForce = force;
+}
+
+void TLMInterface1D::SetInitialFlow(double flow)
+{
+  InitialFlow = flow;
 }
 
 

--- a/common/Interfaces/TLMInterface1D.h
+++ b/common/Interfaces/TLMInterface1D.h
@@ -40,6 +40,7 @@ public:
     std::vector<TLMTimeData1D> DataToSend;
 
     double InitialForce = 0;
+    double InitialFlow = 0;
 
     void UnpackTimeData(TLMMessage &mess);
 
@@ -50,6 +51,7 @@ public:
     void SetTimeData(double time, double position, double speed);
     void SendAllData();
     void SetInitialForce(double force);
+    void SetInitialFlow(double flow);
 
     //! linear_interpolate is called with a vector containing 2 points
     //! computes the interpolation (or extrapolation) point with the the linear

--- a/common/Interfaces/TLMInterface3D.cc
+++ b/common/Interfaces/TLMInterface3D.cc
@@ -222,7 +222,12 @@ void TLMInterface3D::SetTimeData(double time,
     }
 
     //Default values are the initial values
-    memcpy(item.GenForce, InitialForce, sizeof(double)*6);
+    item.GenForce[0] = InitialForce[0] - Params.Zf*InitialFlow[0];
+    item.GenForce[1] = InitialForce[1] - Params.Zf*InitialFlow[1];
+    item.GenForce[2] = InitialForce[2] - Params.Zf*InitialFlow[2];
+    item.GenForce[3] = InitialForce[3] - Params.Zfr*InitialFlow[3];
+    item.GenForce[4] = InitialForce[4] - Params.Zfr*InitialFlow[4];
+    item.GenForce[5] = InitialForce[5] - Params.Zfr*InitialFlow[5];
 
     TLMPlugin::GetForce3D(position, orientation,
                           speed, ang_speed,
@@ -335,6 +340,16 @@ void TLMInterface3D::SetInitialForce(double f1, double f2, double f3, double t1,
     InitialForce[3] = t1;
     InitialForce[4] = t2;
     InitialForce[5] = t3;
+}
+
+void TLMInterface3D::SetInitialFlow(double v1, double v2, double v3, double w1, double w2, double w3)
+{
+  InitialFlow[0] = v1;
+  InitialFlow[1] = v2;
+  InitialFlow[2] = v3;
+  InitialFlow[3] = w1;
+  InitialFlow[4] = w2;
+  InitialFlow[5] = w3;
 }
 
 

--- a/common/Interfaces/TLMInterface3D.h
+++ b/common/Interfaces/TLMInterface3D.h
@@ -40,6 +40,7 @@ public:
     std::vector<TLMTimeData3D> DataToSend;
 
     double InitialForce[6] = {0,0,0,0,0,0};
+    double InitialFlow[6]  = {0,0,0,0,0,0};
 
     //! Evaluate the data from deque for the time specified by this Instance
     //! If OnleForce is set, then the position and velocity are not computed.
@@ -53,6 +54,7 @@ public:
     void TransformTimeDataToCG(std::vector<TLMTimeData3D> &timeData, TLMConnectionParams &params);
     void SendAllData();
     void SetInitialForce(double f1, double f2, double f3, double t1, double t2, double t3);
+    void SetInitialFlow(double v1, double v2, double v3, double w1, double w2, double w3);
 
     //! linear_interpolate is called with a vector containing 2 points
     //! computes the interpolation (or extrapolation) point with the the linear

--- a/common/Plugin/PluginImplementer.cc
+++ b/common/Plugin/PluginImplementer.cc
@@ -58,6 +58,17 @@ void PluginImplementer::SetInitialForce3D(int interfaceID, double f1, double f2,
     ifc->SetInitialForce(f1,f2,f3,t1,t2,t3);
 }
 
+void PluginImplementer::SetInitialFlow3D(int interfaceID, double v1, double v2, double v3, double w1, double w2, double w3)
+{
+  // Use the ID to get to the right interface object
+  int idx = GetInterfaceIndex(interfaceID);
+  TLMInterface3D* ifc = dynamic_cast<TLMInterface3D*>(Interfaces[idx]);
+
+  assert(!ifc || (ifc -> GetInterfaceID() == interfaceID));
+
+  ifc->SetInitialFlow(v1,v2,v3,w1,w2,w3);
+}
+
 void PluginImplementer::SetInitialValue(int interfaceID, double value)
 {
     // Use the ID to get to the right interface object
@@ -71,8 +82,6 @@ void PluginImplementer::SetInitialValue(int interfaceID, double value)
 
 void PluginImplementer::SetInitialForce1D(int interfaceID, double force)
 {
-    //if(!ModelChecked) CheckModel();
-
     // Use the ID to get to the right interface object
     int idx = GetInterfaceIndex(interfaceID);
     TLMInterface1D* ifc = dynamic_cast<TLMInterface1D*>(Interfaces[idx]);
@@ -80,6 +89,17 @@ void PluginImplementer::SetInitialForce1D(int interfaceID, double force)
     assert(!ifc || (ifc -> GetInterfaceID() == interfaceID));
 
     ifc->SetInitialForce(force);
+}
+
+void PluginImplementer::SetInitialFlow1D(int interfaceID, double flow)
+{
+  // Use the ID to get to the right interface object
+  int idx = GetInterfaceIndex(interfaceID);
+  TLMInterface1D* ifc = dynamic_cast<TLMInterface1D*>(Interfaces[idx]);
+
+  assert(!ifc || (ifc -> GetInterfaceID() == interfaceID));
+
+  ifc->SetInitialFlow(flow);
 }
 
 

--- a/common/Plugin/PluginImplementer.h
+++ b/common/Plugin/PluginImplementer.h
@@ -33,7 +33,11 @@ public:
     void SetInitialForce3D(int interfaceID,
                            double f1, double f2, double f3,
                            double t1, double t2, double t3);
+    void SetInitialFlow3D(int interfaceID,
+                          double v1, double v2, double v3,
+                          double w1, double w2, double w3);
     void SetInitialForce1D(int interfaceID, double force);
+    void SetInitialFlow1D(int interfaceID, double flow);
     void SetInitialValue(int interfaceID, double value);
 
 protected:
@@ -181,7 +185,7 @@ protected:
 
     //! StartTime - start time for the simulation
     double StartTime;
-    
+
     //! End time for the simulation
     double EndTime;
 

--- a/common/Plugin/TLMPlugin.h
+++ b/common/Plugin/TLMPlugin.h
@@ -133,9 +133,13 @@ public:
 
     virtual void SetInitialValue(int interfaceID, double value) = 0;
     virtual void SetInitialForce1D(int interfaceID, double force) = 0;
+    virtual void SetInitialFlow1D(int interfaceID, double flow) = 0;
     virtual void SetInitialForce3D(int interfaceID,
                                    double f1, double f2, double f3,
                                    double t1, double t2, double t3) = 0;
+    virtual void SetInitialFlow3D(int interfaceID,
+                                   double v1, double v2, double v3,
+                                   double w1, double w2, double w3) = 0;
 
     //! Check if the object is initialized (Init was called).
     bool IsInitialized() const { return Initialized; }


### PR DESCRIPTION
Added API function for setting initial flow, just like initial force. They are used together to compute initial wave variables.

Related to OpenModelica/OMSimulator#258.