### PR TITLE
Delete TLM monitor after simulation

### DIFF
--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -834,6 +834,8 @@ int startMonitor(double timeStep,
 
   } while(simTime < endTime);
 
+  delete thePlugin;
+
   return 0;
 }
 


### PR DESCRIPTION
Added missing delete of the MonitoringPluginImplementer object. This seem to fix a lot of memory leaks reported by ASan.