### PR TITLE
Expose CheckModel() to slaves

### DIFF
--- a/common/Plugin/PluginImplementer.h
+++ b/common/Plugin/PluginImplementer.h
@@ -40,6 +40,10 @@ public:
     void SetInitialFlow1D(int interfaceID, double flow);
     void SetInitialValue(int interfaceID, double value);
 
+    //! CheckModel method results in CheckModel request sent to TLM manager.
+    //! The successful return indicates that the simulation is ready to run.
+    void CheckModel();
+
 protected:
     //! Connected flag tells if the connection to TLM manager is established.
     bool Connected;
@@ -49,10 +53,6 @@ protected:
 
     //! Checked flag tells if the manager confirmed start of a simulation
     bool ModelChecked;
-
-    //! CheckModel method results in CheckModel request sent to TLM manager.
-    //! The successful return indicates that the simulation is ready to run.
-    void CheckModel();
 
     //! Registered interfaces
     std::vector<omtlm_TLMInterface*> Interfaces;

--- a/common/Plugin/TLMPlugin.h
+++ b/common/Plugin/TLMPlugin.h
@@ -141,6 +141,8 @@ public:
                                    double v1, double v2, double v3,
                                    double w1, double w2, double w3) = 0;
 
+    virtual void CheckModel() = 0;
+
     //! Check if the object is initialized (Init was called).
     bool IsInitialized() const { return Initialized; }
 


### PR DESCRIPTION
Enable slaves to explicitly call CheckModel() when they are ready to send/receive messages.

Related to OpenModelica/OMSimulator#338