### PR TITLE
Prevent multiple close of TLMErrorLog

### DIFF
--- a/common/Logging/TLMErrorLog.cc
+++ b/common/Logging/TLMErrorLog.cc
@@ -61,9 +61,10 @@ void TLMErrorLog::Open() {
 void TLMErrorLog::Close()
 {
   LogStreamLock.lock();
-  if(outStream!=NULL) {
+  if(outStream!=nullptr) {
     *outStream << TimeStr() << " Log finished." << std::endl;
     delete outStream;
+    outStream = nullptr;
     LogLevel = Disabled;
   }
   LogStreamLock.unlock();


### PR DESCRIPTION
When multiple threads share the same TLMErrorLog, they may all attempt to close it. If it is already closed, do nothing.