### PR TITLE
Fix monitor shutdown

### DIFF
--- a/common/Communication/ManagerCommHandler.h
+++ b/common/Communication/ManagerCommHandler.h
@@ -38,6 +38,7 @@ private:
     omtlm_CompositeModel& TheModel;
 
     bool MonitorConnected;
+    bool MonitorDisconnected;
 
 public:
     //! The communication protocol modes, i.e., real co-simulation or interface information request.
@@ -74,6 +75,7 @@ public:
         Comm(Model.GetComponentsNum(), Model.GetSimParams().GetPort()),
         TheModel(Model),
         MonitorConnected(false),
+        MonitorDisconnected(false),
         CommMode(CoSimulationMode),
         monitorInterfaceMap(),
         monitorMapLock(),

--- a/common/Communication/TLMCommUtil.cc
+++ b/common/Communication/TLMCommUtil.cc
@@ -50,7 +50,7 @@ void TLMCommUtil::SendMessage(TLMMessage& mess) {
 
     if(sendBytes < 0) {
         // try to resend
-        TLMErrorLog::Warning("Failed to send message header, will try to continue anyway");
+        TLMErrorLog::Warning("Failed to send message header, will try again (code: "+std::to_string(sendBytes)+"), type = "+std::to_string(mess.Header.MessageType));
         sendBytes = send(mess.SocketHandle, (const char*)&(mess.Header) , sizeof(TLMMessageHeader), MSG_MORE);
     }
 

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -1258,6 +1258,7 @@ void omtlm_setStopTime(void *pModel, double stopTime)
 void omtlm_setLogLevel(void *pModel, int logLevel) {
   CompositeModelProxy *pModelProxy = (CompositeModelProxy*)pModel;
   pModelProxy->logLevel = logLevel;
+  TLMErrorLog::SetLogLevel(TLMLogLevel(pModelProxy->logLevel));
 }
 
 void omtlm_checkPortAvailability(int *port) {

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -1033,6 +1033,8 @@ void simulateInternal(void *pModel,
   managerThread.join();
   std::cout << "Manager thread finished.\n";
 
+  TLMErrorLog::Close();
+
   return;
 }
 

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -846,6 +846,9 @@ int startMonitor(double timeStep,
     simTime += timeStep;
   } while(simTime < endTime);
 
+  TLMErrorLog::Info("Monitor sending close request (simTime = "+std::to_string(simTime)+", endTime = "+std::to_string(endTime)+")");
+  thePlugin->SendCloseNotification();
+
   delete thePlugin;
 
   return 0;

--- a/common/Plugin/PluginImplementer.cc
+++ b/common/Plugin/PluginImplementer.cc
@@ -149,7 +149,6 @@ PluginImplementer::~PluginImplementer() {
         it != Interfaces.end(); ++it) {
         delete (*it);
     }
-    TLMErrorLog::Close();
 
     delete Message;
 }

--- a/common/Plugin/PluginImplementer.cc
+++ b/common/Plugin/PluginImplementer.cc
@@ -40,13 +40,20 @@ void PluginImplementer::InterfaceReadyForTakedown(std::string IfcName) {
 
 void PluginImplementer::AwaitClosePermission()
 {
-  TLMErrorLog::Info("Awaiting close permission...");
-  Message->Header.MessageType = TLMMessageTypeConst::TLM_CLOSE_REQUEST;
-  TLMCommUtil::SendMessage(*Message);
-  while(Message->Header.MessageType != TLMMessageTypeConst::TLM_CLOSE_PERMISSION) {
-    TLMCommUtil::ReceiveMessage(*Message);
-  }
-  TLMErrorLog::Info("Close permission received.");
+    Message->Header.MessageType = TLMMessageTypeConst::TLM_CLOSE_REQUEST;
+    TLMCommUtil::SendMessage(*Message);
+    while(Message->Header.MessageType != TLMMessageTypeConst::TLM_CLOSE_PERMISSION) {
+        TLMErrorLog::Info("Awaiting close permission...");
+        TLMCommUtil::ReceiveMessage(*Message);
+    }
+    TLMErrorLog::Info("Close permission received.");
+}
+
+void PluginImplementer::SendCloseNotification()
+{
+    Message->Header.MessageType = TLMMessageTypeConst::TLM_CLOSE_REQUEST;
+    TLMCommUtil::SendMessage(*Message);
+    TLMErrorLog::Info("Close notification sent.");
 }
 
 void PluginImplementer::SetInitialForce3D(int interfaceID, double f1, double f2, double f3, double t1, double t2, double t3)

--- a/common/Plugin/PluginImplementer.h
+++ b/common/Plugin/PluginImplementer.h
@@ -91,6 +91,7 @@ protected:
     void InterfaceReadyForTakedown(std::string IfcName);
 
     void AwaitClosePermission();
+    void SendCloseNotification();
 
     //! Register TLM interface sends a registration request to TLMManager
     //! and returns the ID for the interface. '-1' is returned if

--- a/common/Plugin/TLMPlugin.h
+++ b/common/Plugin/TLMPlugin.h
@@ -54,6 +54,7 @@ public:
                        std::string serverName) = 0;
 
     virtual void AwaitClosePermission() = 0;
+    virtual void SendCloseNotification() = 0;
 
     //! Register TLM interface sends a registration request to TLMManager
     //! and returns the ID for the interface. '-1' is returned if


### PR DESCRIPTION
- Use close request messages also for monitor
- Don't attempt to send data to monitor if it is disconnected
- Resend failed messages 10 times, then abort simulation
- Don't close TLM error log in each thread
- Apply TLM log level at very beginning, to catch early messages