### PR TITLE
Close connection to monitor after slaves

### DIFF
--- a/common/Communication/ManagerCommHandler.h
+++ b/common/Communication/ManagerCommHandler.h
@@ -37,8 +37,11 @@ private:
     //! Meta-model
     omtlm_CompositeModel& TheModel;
 
+
+    std::vector<int> MonitorSockets;
     bool MonitorConnected;
-    bool MonitorDisconnected;
+    bool MonitorsDisconnected;
+    std::vector<int> DisconnectedMonitors;
 
 public:
     //! The communication protocol modes, i.e., real co-simulation or interface information request.
@@ -75,7 +78,7 @@ public:
         Comm(Model.GetComponentsNum(), Model.GetSimParams().GetPort()),
         TheModel(Model),
         MonitorConnected(false),
-        MonitorDisconnected(false),
+        MonitorsDisconnected(false),
         CommMode(CoSimulationMode),
         monitorInterfaceMap(),
         monitorMapLock(),

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -847,7 +847,7 @@ int startMonitor(double timeStep,
   } while(simTime < endTime);
 
   TLMErrorLog::Info("Monitor sending close request (simTime = "+std::to_string(simTime)+", endTime = "+std::to_string(endTime)+")");
-  thePlugin->SendCloseNotification();
+  thePlugin->AwaitClosePermission();
 
   delete thePlugin;
 

--- a/common/Plugin/PluginImplementer.cc
+++ b/common/Plugin/PluginImplementer.cc
@@ -49,13 +49,6 @@ void PluginImplementer::AwaitClosePermission()
     TLMErrorLog::Info("Close permission received.");
 }
 
-void PluginImplementer::SendCloseNotification()
-{
-    Message->Header.MessageType = TLMMessageTypeConst::TLM_CLOSE_REQUEST;
-    TLMCommUtil::SendMessage(*Message);
-    TLMErrorLog::Info("Close notification sent.");
-}
-
 void PluginImplementer::SetInitialForce3D(int interfaceID, double f1, double f2, double f3, double t1, double t2, double t3)
 {
     // Use the ID to get to the right interface object

--- a/common/Plugin/PluginImplementer.h
+++ b/common/Plugin/PluginImplementer.h
@@ -91,7 +91,6 @@ protected:
     void InterfaceReadyForTakedown(std::string IfcName);
 
     void AwaitClosePermission();
-    void SendCloseNotification();
 
     //! Register TLM interface sends a registration request to TLMManager
     //! and returns the ID for the interface. '-1' is returned if

--- a/common/Plugin/TLMPlugin.h
+++ b/common/Plugin/TLMPlugin.h
@@ -54,7 +54,6 @@ public:
                        std::string serverName) = 0;
 
     virtual void AwaitClosePermission() = 0;
-    virtual void SendCloseNotification() = 0;
 
     //! Register TLM interface sends a registration request to TLMManager
     //! and returns the ID for the interface. '-1' is returned if


### PR DESCRIPTION
Related to #109 and OpenModelica/OMSimulator#618

- Wait for close persmission before closing monitor socket
- Send close permission to monitor _after_ closing all slave sockets
