### PR TITLE
Remove AF_INET check in TLM manager

### DIFF
--- a/common/Communication/TLMManagerComm.cc
+++ b/common/Communication/TLMManagerComm.cc
@@ -37,11 +37,6 @@ int TLMManagerComm::CreateServerSocket() {
 
     struct sockaddr_in sa;  // My socket addr.
 
-#define MAXHOSTNAME 1024
-
-    char myname[MAXHOSTNAME+1];
-    struct hostent *hp;
-
 #ifdef WIN32
     WSADATA ws;
     int d;
@@ -50,22 +45,7 @@ int TLMManagerComm::CreateServerSocket() {
 #endif
 
     memset(&sa,0, sizeof(struct sockaddr_in));
-    gethostname(myname,MAXHOSTNAME);
-    hp = gethostbyname((const char*) myname);
-
-    if(hp==NULL) {
-        TLMErrorLog::FatalError("Create server socket - failed to get my hostname, check that name resolves, e.g. /etc/hosts has "+std::string(myname));
-        // See BZ2161.
-
-        // Adding this line to /etc/hosts resolves (for me) the problem with
-        //  "Create server socket - failed to get my hostname"
-
-        // 127.0.0.3       homer.mathcore.local
-
-
-        return -1;
-    }
-    sa.sin_family = hp->h_addrtype;
+    sa.sin_family = AF_INET;
 
 #ifdef WIN32
     char* localIP;
@@ -73,10 +53,6 @@ int TLMManagerComm::CreateServerSocket() {
     sa.sin_addr.s_addr = inet_addr(localIP);
 #endif
 
-    if(AF_INET != sa.sin_family) {
-        TLMErrorLog::FatalError("Unsupported address family returned by gethostbyname");
-        return -1;
-    }
     sa.sin_port = htons(ServerPort);
 
     int theSckt;


### PR DESCRIPTION
Remove unnecessary check for AF_INET. Check is not needed, and the check itself may fail on some architectures. Related to #111.