### PR TITLE
Option to override socket address

### DIFF
--- a/common/CompositeModels/CompositeModel.cc
+++ b/common/CompositeModels/CompositeModel.cc
@@ -33,23 +33,31 @@ string SimulationParams::GetServerName() const {
 #define MAXHOSTNAME 1024
 
     char Buf[MAXHOSTNAME + 50];
-    gethostname(Buf, MAXHOSTNAME); // this sometimes return unreliable (short) names
-    
-    // getting IP
-    struct hostent *hp;
-    hp = gethostbyname(Buf);
+    if(Address != "") {
+        gethostname(Buf, MAXHOSTNAME); // this sometimes return unreliable (short) names
 
-    if(hp==NULL) {
-        TLMErrorLog::FatalError("GetServerName: Failed to get my host IP");
-        return string();
+        // getting IP
+        struct hostent *hp;
+        hp = gethostbyname(Buf);
+
+        if(hp==NULL) {
+            TLMErrorLog::FatalError("GetServerName: Failed to get my host IP");
+            return string();
+        }
+
+        char* localIP;
+        localIP = inet_ntoa (*(struct in_addr *)*hp->h_addr_list);
+        sprintf(Buf,"%s:%d", localIP, Port);
     }
-
-    char* localIP;
-    localIP = inet_ntoa (*(struct in_addr *)*hp->h_addr_list);
+    else {
+        std::string serverName = Address+":"+std::to_string(Port);
+        std::cout << "Server name: " << serverName << "\n";
+        return serverName;
+    }
 
     ////////
 
-    sprintf(Buf,"%s:%d", localIP, Port);
+
     return string(Buf);
 }
 

--- a/common/CompositeModels/CompositeModel.h
+++ b/common/CompositeModels/CompositeModel.h
@@ -395,6 +395,8 @@ class SimulationParams {
     //! Defaults is (TimeEnd-TimeStart)/1000.0
     double WriteTimeStep;
 
+    std::string Address;
+
     //! Port where the server is listening
     int Port;
 
@@ -409,11 +411,12 @@ public:
 
     //! Constructor
     SimulationParams() {
-        Set(0, 0.0, 0.0);
+        Set("", 0, 0.0, 0.0);
     }
 
     //! Set method assign the attributes of the object
-    void Set(int aPort, double StartTime, double StopTime, int aTimeout = 600, int aMonitorPort = -1) {
+    void Set(std::string address, int aPort, double StartTime, double StopTime, int aTimeout = 600, int aMonitorPort = -1) {
+        Address = address;
         Port = aPort;
         TimeStart = StartTime;
         TimeEnd = StopTime;
@@ -425,6 +428,10 @@ public:
     //! Get the port number
     int GetPort() const {
         return Port;
+    }
+
+    void SetAddress(std::string address) {
+        Address = address;
     }
 
     //! Set the port number
@@ -442,6 +449,11 @@ public:
         MonitorPort = aPort;
     }
 
+    //! Set simulation start time
+    void SetStartTime(double StartTime) {
+        TimeStart = StartTime;
+    }
+
     //! Get simulation start time
     double GetStartTime() const {
         return TimeStart;
@@ -452,6 +464,11 @@ public:
         char Buf[50];
         sprintf(Buf, "%g", TimeStart);
         return std::string(Buf);
+    }
+
+    //! Set simulation end time
+    void SetEndTime(double EndTime) {
+        TimeEnd = EndTime;
     }
 
     //! Get simulation end time

--- a/common/CompositeModels/CompositeModelReader.cc
+++ b/common/CompositeModels/CompositeModelReader.cc
@@ -262,7 +262,9 @@ void CompositeModelReader::ReadSimParams(xmlNode* node) {
     //std::string Infile = (const char*)curAttrVal->content;
 
     // Note, order is important here!
-    TheModel.GetSimParams().Set(Port, StartTime, StopTime);
+    TheModel.GetSimParams().SetPort(Port);
+    TheModel.GetSimParams().SetStartTime(StartTime);
+    TheModel.GetSimParams().SetEndTime(StopTime);
     TheModel.GetSimParams().SetWriteTimeStep(WriteTimeStep);
 
     TLMErrorLog::Info("StartTime     = "+TLMErrorLog::ToStdStr(StartTime)+" s");

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -930,12 +930,15 @@ void PrintInterfaceInformation(omtlm_CompositeModel& theModel) {
 
 
 
-int startManager(int serverPort,
+int startManager(std::string address,
+                 int serverPort,
                  int monitorPort,
                  ManagerCommHandler::CommunicationMode comMode,
                  omtlm_CompositeModel &model) {
 
   TLMErrorLog::Info("Printing from manager thread.");
+
+  model.GetSimParams().SetAddress(address);
 
   // Set preferred network port
   if(serverPort > 0) {
@@ -1008,6 +1011,7 @@ void simulateInternal(void *pModel,
 
   // Start manager thread
   std::thread managerThread = std::thread(startManager,
+                                          pModelProxy->serverAddress,
                                           pModelProxy->managerPort,
                                           pModelProxy->monitorPort,
                                           comMode,
@@ -1236,7 +1240,7 @@ void omtlm_setStartTime(void *pModel, double startTime)
 
   double stopTime = pModelProxy->stopTime;
   omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
-  pCompositeModel->GetSimParams().Set(11111,startTime,stopTime);
+  pCompositeModel->GetSimParams().SetStartTime(startTime);
 
   double writeTimeStep = (stopTime-startTime)/1000.0;
   pCompositeModel->GetSimParams().SetWriteTimeStep(writeTimeStep);
@@ -1249,7 +1253,7 @@ void omtlm_setStopTime(void *pModel, double stopTime)
 
   double startTime = pModelProxy->startTime;
   omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
-  pCompositeModel->GetSimParams().Set(11111,startTime,stopTime);
+  pCompositeModel->GetSimParams().SetEndTime(stopTime);
 
   double writeTimeStep = (stopTime-startTime)/1000.0;
   pCompositeModel->GetSimParams().SetWriteTimeStep(writeTimeStep);


### PR DESCRIPTION
- Added option to override socket address
- If not used, socket address from manager will be read from hostname automatically
- OMTLMSimulator library will use this feature by calling `omtlm_setAddress`