### PR TITLE
Various TLM fixes

### DIFF
--- a/Hopsan/TLMPluginLib/TLMPluginHandler.hpp
+++ b/Hopsan/TLMPluginLib/TLMPluginHandler.hpp
@@ -32,6 +32,7 @@
 
 // TLMPlugin includes
 #include "Plugin/TLMPlugin.h"
+#include "Logging/TLMErrorLog.h"
 
 namespace hopsan {
 
@@ -84,10 +85,10 @@ namespace hopsan {
                     TLMErrorLog::SetOutStream(mDebugOutFile);
                 }
 
-                TLMErrorLog::SetLogLevel(TLMLogLevel::Debug);
+                TLMErrorLog::SetLogLevel(Debug);
             }
             else {
-                TLMErrorLog::SetLogLevel(TLMLogLevel::Warning);
+                TLMErrorLog::SetLogLevel(Warning);
             }
 
             //Register parameters

--- a/Hopsan/TLMPluginLib/TLMPluginLib.xml
+++ b/Hopsan/TLMPluginLib/TLMPluginLib.xml
@@ -2,21 +2,29 @@
 <hopsancomponentlibrary name="TLMPluginLib" xmlversion="0.1" libversion="1">
     <lib debug_ext="_d">TLMPluginLib</lib>
     <source>TLMPluginLib.cc</source>
-    <source>../../common/PluginImplementer.cc</source>
-    <source>../../common/TLMClientComm.cc</source>
-    <source>../../common/TLMCommUtil.cc</source>
-    <source>../../common/TLMErrorLog.cc</source>
-    <source>../../common/TLMInterface.cc</source>
-    <source>../../common/TLMInterfaceSignalInput.cc</source>
-    <source>../../common/TLMInterfaceSignalOutput.cc</source>
-    <source>../../common/TLMInterfaceSignal.cc</source>
-    <source>../../common/TLMInterface1D.cc</source>
-    <source>../../common/TLMInterface3D.cc</source>
-    <source>../../common/TLMPlugin.cc</source>
-    <source>../../3rdParty/misc/src/tostr.cc</source>
+    <source>../../common/Plugin/PluginImplementer.cc</source>
+    <source>../../common/Communication/TLMClientComm.cc</source>
+    <source>../../common/Communication/TLMCommUtil.cc</source>
+    <source>../../common/Logging/TLMErrorLog.cc</source>
+    <source>../../common/Interfaces/TLMInterface.cc</source>
+    <source>../../common/Plugin/TLMPlugin.cc</source>
+    <source>../../3rdParty/misc/src/Bstring.cc</source>
+    <source>../../3rdParty/misc/src/ErrorLog.cc</source>
     <source>../../3rdParty/misc/src/coordTransform.cc</source>
     <source>../../3rdParty/misc/src/double3.cc</source>
     <source>../../3rdParty/misc/src/double33.cc</source>
+    <source>../../3rdParty/misc/src/double33s.cc</source>
+    <source>../../3rdParty/misc/src/dsyevq3.cc</source>
+    <source>../../3rdParty/misc/src/dsyevv3.cc</source>
+    <source>../../3rdParty/misc/src/dsytrd3.cc</source>
+    <source>../../3rdParty/misc/src/dsyevc3.cc</source>
+    <source>../../3rdParty/misc/src/tostr.cc</source>
+    <source>../../common/Interfaces/TLMInterfaceSignal.cc</source>
+    <source>../../common/Interfaces/TLMInterfaceSignalInput.cc</source>
+    <source>../../common/Interfaces/TLMInterfaceSignalOutput.cc</source>
+    <source>../../common/Interfaces/TLMInterface1D.cc</source>
+    <source>../../common/Interfaces/TLMInterface3D.cc</source>
+    <source>../../common/Parameters/ComponentParameter.cc</source>
     <component>TLMPluginHandler.hpp</component>
     <component>TLMPluginInterfaceSignalInput.hpp</component>
     <component>TLMPluginInterfaceSignalOutput.hpp</component>
@@ -26,7 +34,6 @@
     <caf>TLMPluginInterface1D.xml</caf>
     <caf>TLMPluginHandler.xml</caf>
     <buildflags>
-      <cflags>-I../../common -I../../extralibs/misc/include</cflags>
-      <lflags>-lws2_32</lflags>
+      <cflags>-I../../common -I../../3rdParty/misc/include -std=c++11</cflags>
     </buildflags>
 </hopsancomponentlibrary>

--- a/common/Communication/TLMClientComm.cc
+++ b/common/Communication/TLMClientComm.cc
@@ -210,6 +210,9 @@ int TLMClientComm::ConnectManager(string& callname, int portnr) {
         TLMErrorLog::Info("TLM manager host found, trying to connect...");
     }
 
+    bool val = true;
+    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*)&val, sizeof(int));
+
     count = 0;
 
     while(connect(s, (struct sockaddr *) &sa, sizeof(sa)) < 0) {

--- a/common/Communication/TLMManagerComm.cc
+++ b/common/Communication/TLMManagerComm.cc
@@ -71,6 +71,9 @@ int TLMManagerComm::CreateServerSocket() {
         return -1;
     }
 
+    bool val = true;
+    setsockopt(theSckt, SOL_SOCKET, SO_REUSEADDR, (char*)&val, sizeof(int));
+
     int bindCount = 0;
     int maxIterations = 1000; // BUG: should be calculated from a max. port range!
     // Bind the socket, first try the predefined port, then increase port number.

--- a/common/OMTLMSimulatorMain.cc
+++ b/common/OMTLMSimulatorMain.cc
@@ -155,8 +155,9 @@ int main(int argc, char *argv[])
   // Start simulation //
   //////////////////////
 
-  //void* pModel = omtlm_loadModel(options.model.c_str());
-
+  void* pModel = omtlm_loadModel(options.model.c_str());
+  omtlm_setLogLevel(pModel, options.logLevel);
+/*
   void *pModel = omtlm_newModel("FmiTest");
   omtlm_addSubModel(pModel, "adder","/home/robbr48/Documents/Git/OMTLMSimulator/CompositeModels/FmiTestLinux/cs_adder1fmu1/cs_adder1.fmu", "StartTLMFmiWrapper");
   omtlm_addSubModel(pModel, "source1","/home/robbr48/Documents/Git/OMTLMSimulator/CompositeModels/FmiTestLinux/cs_source1fmu1/cs_source1.fmu", "StartTLMFmiWrapper");
@@ -190,7 +191,7 @@ int main(int argc, char *argv[])
   omtlm_setMonitorPort( pModel, options.monitor);
   omtlm_setNumLogStep(  pModel, options.numLogSteps);
   omtlm_setLogStepSize( pModel, options.logStepSize);
-
+*/
   std::cout << "Starting simulation.\n";
 
   omtlm_simulate(pModel);

--- a/common/OMTLMSimulatorMain.cc
+++ b/common/OMTLMSimulatorMain.cc
@@ -117,7 +117,7 @@ struct optionsType {
 
     FILE *modelFile = fopen(model.c_str(), "r");
     if (!modelFile) {
-      std::cout << "Error: Model file does not exist or is not accessible.\n";
+      std::cout << "Error: Model file does not exist or is not accessible: " << model << "\n";
       exit(-1);
     }
     fclose(modelFile);

--- a/common/Plugin/PluginImplementer.cc
+++ b/common/Plugin/PluginImplementer.cc
@@ -255,7 +255,7 @@ int  PluginImplementer::RegisteTLMInterface(std::string name , int dimensions,
         ifc = new TLMInterfaceOutput(ClientComm, name, StartTime, domain);
     }
     else {
-        TLMErrorLog::FatalError("Unknown interface type : "+domain+":"+std::to_string(dimensions));
+        TLMErrorLog::FatalError("Unknown interface type : "+domain+":"+std::to_string(dimensions)+" ("+causality+")");
     }
 
     int id = ifc->GetInterfaceID();


### PR DESCRIPTION
- Reusable socket addresses
- More clear error messages
- Compile Hopsan plugin with latest changes
- Use specified model file and log level in OMTLMSimulator executable