### PR TITLE
API for fetching submodel interfaces

### DIFF
--- a/common/CompositeModels/CompositeModel.h
+++ b/common/CompositeModels/CompositeModel.h
@@ -286,6 +286,16 @@ public:
         return Name;
     }
 
+    //! read the start command
+    std::string& GetStartCommand() {
+        return StartCommand;
+    }
+
+    //! read the model file
+    std::string& GetModelFile() {
+        return ModelName;
+    }
+
     //! Start the component executable
     void StartComponent(SimulationParams& SimParams, double MaxStep);
 
@@ -411,7 +421,7 @@ public:
 
     //! Constructor
     SimulationParams() {
-        Set("", 0, 0.0, 0.0);
+        Set("127.0.0.1", 11111, 0.0, 1.0, 12111);
     }
 
     //! Set method assign the attributes of the object

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -1000,9 +1000,21 @@ void simulateInternal(void *pModel,
   }
 
 
-  omtlm_CompositeModel *pCompositeModel = pModelProxy->mpCompositeModel;
-
-  pCompositeModel->CheckTheModel();
+  omtlm_CompositeModel *pCompositeModel;
+  if(interfaceRequest) {
+     int id = pModelProxy->mpCompositeModel->GetTLMComponentID(singleModel);
+     TLMComponentProxy proxy = pModelProxy->mpCompositeModel->GetTLMComponentProxy(id);
+     pCompositeModel = new omtlm_CompositeModel();
+     pCompositeModel->RegisterTLMComponentProxy(proxy.GetName(),
+                                                proxy.GetStartCommand(),
+                                                proxy.GetModelFile(),
+                                                false,
+                                                "");
+  }
+  else {
+    pCompositeModel = pModelProxy->mpCompositeModel;
+    pCompositeModel->CheckTheModel();
+  }
 
   std::string modelName = pCompositeModel->GetModelName();
 
@@ -1355,4 +1367,12 @@ void omtlm_printModelStructure(void *pModel)
 {
   CompositeModelProxy *pModelProxy = (CompositeModelProxy*)pModel;
   pModelProxy->mpCompositeModel->Print(std::cout);
+}
+
+void omtlm_fetchInterfaces(void *pModel, const char *subModelName)
+{
+    std::string nameStr(subModelName);
+    simulateInternal(pModel,
+                     true,
+                     nameStr);
 }

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.h
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.h
@@ -76,6 +76,14 @@ DLLEXPORT void omtlm_addInterface(void* pModel,
                   const char *causality,
                   const char *domain);
 
+/**
+ * @brief omtlm_fetchInterfaces
+ * @param pModel Model as opaque pointer.
+ * @param subModelName Name of sub-model.
+ */
+DLLEXPORT void omtlm_fetchInterfaces(void* pModel,
+                                     const char *subModelName);
+
 DLLEXPORT void omtlm_setInitialPositionAndOrientation(void *pModel,
                                                       const char* interfaceName,
                                                       std::vector<double> position,


### PR DESCRIPTION
OMTLMSimulator API for fetching external model interfaces.  

`omtlm_fetchInterfaces` will start a single-step simulation with a single external model. Interface data will be written to interfaceData.xml in the current directory.

Required by OpenModelica/OMSimulator#704.