### PR TITLE
Install signal handler just before starting components

### DIFF
--- a/common/CompositeModels/CompositeModel.cc
+++ b/common/CompositeModels/CompositeModel.cc
@@ -154,7 +154,6 @@ void child_signal_handler(int s) {
 
 // Constructor
 omtlm_CompositeModel::omtlm_CompositeModel() {
-    signal(SIGCHLD, child_signal_handler);
 }
 #endif
 
@@ -366,6 +365,7 @@ int omtlm_CompositeModel::RegisterTLMConnection(int ifc1, int ifc2, TLMConnectio
 
 // Start components
 void omtlm_CompositeModel::StartComponents() {
+    signal(SIGCHLD, child_signal_handler);
     for(unsigned i = 0; i < Components.size(); i++) {
         TLMErrorLog::Info(string("-----  Starting External Tool  ----- "));
         TLMErrorLog::Info("Name: "+Components[i]->GetName());


### PR DESCRIPTION
The signal handler in OMTLMSimulator seem to conflict with some Git process features in OMEdit. We don't actually need it until we start the processes (the external models), since it only catches SIGCHLD i.e. return codes from child processes. Therefore I moved it to the 'StartComponents` function.

Perhaps this needs a more proper solution later, but this works for the moment at least.