### PR TITLE
fix libxml2.so for linux32

### DIFF
--- a/Makefile.head
+++ b/Makefile.head
@@ -136,7 +136,7 @@ XTRLIBS-LINUX64=-lrt
 LIBPTHREAD-LINUX64=-L$(UP)/extralibs/pthread/$(ABI)/lib -lpthread
 
 INCLXML-LINUX32=-I$(UP)/../3rdParty/libxml2/install/linux/include/libxml2
-LIBXML-LINUX32=-L$(UP)/../3rdParty/libxml2/install/linux/lib -lxml2
+LIBXML-LINUX32=-L$(UP)/../3rdParty/libxml2/install/linux/lib -llibxml2.so.2
 CP-LIBXML-LINUX32=
 XTRLIBS-LINUX32=-lrt
 LIBPTHREAD-LINUX32=-L$(UP)/extralibs/pthread/$(ABI)/lib -lpthread


### PR DESCRIPTION
### Purpose

This PR attempts to fix linking `libxml2.so`  for` linux32 bit`