### PR TITLE
Solving compiler error on Windows with setsockopt 

### DIFF
--- a/common/Communication/TLMClientComm.cc
+++ b/common/Communication/TLMClientComm.cc
@@ -28,7 +28,9 @@ using std::string;
 #include <arpa/inet.h>
 #else
 #include <winsock2.h>
-#define NOMINMAX
+#ifndef NOMINMAX
+  #define NOMINMAX
+#endif
 #include <windows.h>
 #include <cassert>
 #include <io.h>
@@ -210,8 +212,12 @@ int TLMClientComm::ConnectManager(string& callname, int portnr) {
         TLMErrorLog::Info("TLM manager host found, trying to connect...");
     }
 
+#ifdef WIN32
+    const char val = 1;
+#else
     int val = 1;
-    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(int));
+#endif
+    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
 
     count = 0;
 

--- a/common/Communication/TLMCommUtil.h
+++ b/common/Communication/TLMCommUtil.h
@@ -17,7 +17,7 @@
 
 #if defined(WIN32) || defined(__MINGW32__)
 #include <winsock2.h>
-#if !defined(NOMINMAX)
+#ifndef NOMINMAX
 #define NOMINMAX
 #endif
 #include <windows.h>

--- a/common/Communication/TLMManagerComm.cc
+++ b/common/Communication/TLMManagerComm.cc
@@ -23,7 +23,9 @@ using std::string;
 #define BCloseSocket close
 #else
 #include <winsock2.h>
-#define NOMINMAX
+#ifndef NOMINMAX
+  #define NOMINMAX
+#endif
 #include <windows.h>
 #include <cassert>
 #include <io.h>
@@ -71,8 +73,12 @@ int TLMManagerComm::CreateServerSocket() {
         return -1;
     }
 
+#ifdef WIN32
+    const char val = 1;
+#else
     int val = 1;
-    setsockopt(theSckt, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(int));
+#endif
+    setsockopt(theSckt, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
 
     int bindCount = 0;
     int maxIterations = 1000; // BUG: should be calculated from a max. port range!

--- a/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
+++ b/common/OMTLMSimulatorLib/OMTLMSimulatorLib.cc
@@ -36,7 +36,9 @@
 #define BCloseSocket close
 #else
 #include <winsock2.h>
-#define NOMINMAX
+#ifndef NOMINMAX
+  #define NOMINMAX
+#endif
 #include <windows.h>
 #include <cassert>
 #include <io.h>
@@ -1315,8 +1317,12 @@ void omtlm_checkPortAvailability(int *port) {
           return;
       }
 
+#ifdef WIN32
+      const char val = 1;
+#else
       int val = 1;
-      setsockopt(theSckt, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(int));
+#endif
+      setsockopt(theSckt, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
 
       int bindCount = 0;
       int maxIterations = 1000; // BUG: should be calculated from a max. port range!

--- a/common/OMTLMSimulatorMain.cc
+++ b/common/OMTLMSimulatorMain.cc
@@ -5,7 +5,9 @@
 #include <fstream>
 #include <sstream>
 #ifdef _WIN32
-#define NOMINMAX
+#ifndef NOMINMAX
+  #define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Also solving some warnings about `NOMINMAX` defined multiple times.